### PR TITLE
Fixes issue #59: The viewer should load now in the MS Edge browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ## Changes in version 0.2 (in dev.)
 
+* Viewer loads now in the MS Edge browser (#59)
 * Time-series are now loaded in increments so user see constantly growing time-series graph
   instead of doing nothing for tens of seconds until the server returns the complete series (#38)
 * When animating through time, the index into a dataset's time coordinates array is incremented

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -45,6 +45,7 @@ export function updateDatasets() {
            .catch(error => {
                dispatch(postMessage('error', error + ''));
            })
+           // 'then' because Microsoft Edge does not understand method finally
            .then(() => {
                dispatch(removeActivity(UPDATE_DATASETS));
            });

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -45,7 +45,7 @@ export function updateDatasets() {
            .catch(error => {
                dispatch(postMessage('error', error + ''));
            })
-           .finally(() => {
+           .then(() => {
                dispatch(removeActivity(UPDATE_DATASETS));
            });
     };


### PR DESCRIPTION
When accepting this PR the viewer will then load when using the MS EWdge Browser which solves #59.