### PR TITLE
Forman 32 draw user shapes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 
 ## Changes in version 0.2 (in dev.)
 
+* Improved selection of places:
+  - If a place is selected in the list it is zoomed to and highlighted in the map;
+  - Places can now be selected in the map if the select interaction is enabled;
+  - Places are also selected if a time-series line is clicked.
 * Minor fixes:
   * Time-series charts now have constant spacing
 * Restrict zooming out, so that only a single world is shown. (#79)
@@ -24,7 +28,7 @@
   increases viewer loading time for server configurations whose data cubes
   are associated with lots of vector data. (#61)
 * Viewer loads now in the MS Edge browser (#59)
-* Fixed problem where viewer did not zoom to selected place if that is a point location. (#52)
+* Fixed problem where viewer did not showInMap to selected place if that is a point location. (#52)
 * Time-series are now loaded in increments so user see constantly growing time-series graph
   instead of doing nothing for tens of seconds until the server returns the complete series (#38)
 * When animating through time, the index into a dataset's time coordinates array is incremented

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,15 @@
 
 ## Changes in version 0.2 (in dev.)
 
+* Users can now draw polygons and circles and show respective time-series. (#32)
 * Improved selection of places:
   - If a place is selected in the list it is zoomed to and highlighted in the map;
   - Places can now be selected in the map if the select interaction is enabled;
   - Places are also selected if a time-series line is clicked.
 * Minor fixes:
   * Time-series charts now have constant spacing
-* Restrict zooming out, so that only a single world is shown. (#79)
-* Added legal agreement to inform about using HTML local storage. (#77)
+  * Restrict zooming out, so that only a single world is shown. (#79)
+  * Added legal agreement to inform about using HTML local storage. (#77)
 * Users can now generate time series for any selected variable and any selected place. (#50)
   User places can now be also removed, which will remove related time series too.
   Removing time series, on the other hand, does no longer remove user added places.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   - Places can now be selected in the map if the select interaction is enabled;
   - Places are also selected if a time-series line is clicked.
 * Minor fixes:
+  * Colors used for geometries in the map and for lines in the time-series charts are now exactly the same.
   * Time-series charts now have constant spacing
   * Restrict zooming out, so that only a single world is shown. (#79)
   * Added legal agreement to inform about using HTML local storage. (#77)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 ## Changes in version 0.2 (in dev.)
 
 * Users can now draw polygons and circles and show respective time-series. (#32)
-  In totel there are now 4 new interactions with the map:
+  In total there are now 4 new interactions with the map:
   - Select a geometry
   - Draw a point
   - Draw a geometry

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,16 @@
 ## Changes in version 0.2 (in dev.)
 
 * Users can now draw polygons and circles and show respective time-series. (#32)
+  In totel there are now 4 new interactions with the map:
+  - Select a geometry
+  - Draw a point
+  - Draw a geometry
+  - Draw a circle
 * Improved selection of places:
   - If a place is selected in the list it is zoomed to and highlighted in the map;
-  - Places can now be selected in the map if the select interaction is enabled;
+  - Places can now be selected in the map if the "Select" map interaction is active;
   - Places are also selected if a time-series line is clicked.
+    (However, that doesn't work nicely yet due to issues in the Recharts lib).
 * Minor fixes:
   * Colors used for geometries in the map and for lines in the time-series charts are now exactly the same.
   * Time-series charts now have constant spacing

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@date-io/date-fns": "^1.3.9",
     "@material-ui/core": "^4.4.0",
+    "@material-ui/lab": "^4.0.0-alpha.25",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/pickers": "^3.2.4",
     "classnames": "^2.2.6",

--- a/src/actions/controlActions.tsx
+++ b/src/actions/controlActions.tsx
@@ -14,9 +14,9 @@ import {
     updateDatasetPlaceGroup, UPDATE_DATASET_PLACE_GROUP,
     UpdateDatasetPlaceGroup,
 } from './dataActions';
-import { isValidPlaceGroup, PlaceGroup } from '../model/place';
+import { isValidPlaceGroup, Place, PlaceGroup } from '../model/place';
 import { I18N } from '../config';
-import { ControlState, TimeAnimationInterval } from "../states/controlState";
+import { ControlState, MapInteraction, TimeAnimationInterval } from "../states/controlState";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -92,14 +92,13 @@ export type SELECT_PLACE = typeof SELECT_PLACE;
 export interface SelectPlace {
     type: SELECT_PLACE;
     selectedPlaceId: string | null;
-    // TODO: Having datasets in here is ugly, but we need it in the reducer.
-    datasets: Dataset[];
-    // TODO: Having userPlaceGroup in here is ugly, but we need it in the reducer.
-    userPlaceGroup: PlaceGroup;
+    // TODO: Having places in here is ugly, but we need it in the reducer.
+    places: Place[];
+    showInMap: boolean;
 }
 
-export function selectPlace(selectedPlaceId: string | null, datasets: Dataset[], userPlaceGroup: PlaceGroup): SelectPlace {
-    return {type: SELECT_PLACE, selectedPlaceId, datasets, userPlaceGroup};
+export function selectPlace(selectedPlaceId: string | null, places: Place[], showInMap: boolean): SelectPlace {
+    return {type: SELECT_PLACE, selectedPlaceId, places, showInMap};
 }
 
 
@@ -186,6 +185,19 @@ export interface UpdateTimeAnimation {
 
 export function updateTimeAnimation(timeAnimationActive: boolean, timeAnimationInterval: TimeAnimationInterval): UpdateTimeAnimation {
     return {type: UPDATE_TIME_ANIMATION, timeAnimationActive, timeAnimationInterval};
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const SET_MAP_INTERACTION = 'SET_MAP_INTERACTION';
+export type SET_MAP_INTERACTION = typeof SET_MAP_INTERACTION;
+
+export interface SetMapInteraction {
+    type: SET_MAP_INTERACTION;
+    mapInteraction: MapInteraction;
+}
+
+export function setMapInteraction(mapInteraction: MapInteraction): SetMapInteraction {
+    return {type: SET_MAP_INTERACTION, mapInteraction};
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -286,6 +298,7 @@ export type ControlAction =
     | SelectTimeRange
     | SelectTimeSeriesUpdateMode
     | UpdateTimeAnimation
+    | SetMapInteraction
     | AddActivity
     | RemoveActivity
     | ChangeLocale

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -24,7 +24,7 @@ import {
 } from '../selectors/controlSelectors';
 import { Server } from '../model/server';
 import { MessageLogAction, postMessage } from './messageLogActions';
-import { findPlaceInPlaceGroups, PlaceGroup } from '../model/place';
+import { findPlaceInPlaceGroups, Place, PlaceGroup } from '../model/place';
 import * as geojson from 'geojson';
 import { placeGroupsSelector } from '../selectors/dataSelectors';
 
@@ -116,10 +116,11 @@ export type REMOVE_USER_PLACE = typeof REMOVE_USER_PLACE;
 export interface RemoveUserPlace {
     type: REMOVE_USER_PLACE;
     id: string;
+    places: Place[];
 }
 
-export function removeUserPlace(id: string): RemoveUserPlace {
-    return {type: REMOVE_USER_PLACE, id};
+export function removeUserPlace(id: string, places: Place[]): RemoveUserPlace {
+    return {type: REMOVE_USER_PLACE, id, places};
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -26,4 +26,3 @@ class ControlBar extends React.Component<ControlBarProps> {
 }
 
 export default withStyles(styles)(ControlBar);
-

--- a/src/components/MapInteractionsBar.tsx
+++ b/src/components/MapInteractionsBar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import CenterFocusWeakIcon from '@material-ui/icons/CenterFocusWeak';
-import TripOriginIcon from '@material-ui/icons/TripOrigin';
+import CenterFocusStrongIcon from '@material-ui/icons/CenterFocusStrong';
+import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
+import RoomIcon from '@material-ui/icons/Room';
 import CategoryIcon from '@material-ui/icons/Category';
 import FormControl from '@material-ui/core/FormControl';
 import ToggleButton from '@material-ui/lab/ToggleButton';
@@ -20,8 +21,8 @@ const useStyles = makeStyles(theme => ({
 ));
 
 interface MapInteractionsBarProps extends WithLocale {
-    mapInteraction: string;
-    setMapInteraction: (interaction: string) => void;
+    mapInteraction: MapInteraction;
+    setMapInteraction: (interaction: MapInteraction) => void;
 }
 
 export default function MapInteractionsBar({mapInteraction, setMapInteraction}: MapInteractionsBarProps) {
@@ -39,13 +40,16 @@ export default function MapInteractionsBar({mapInteraction, setMapInteraction}: 
         <FormControl className={classes.formControl}>
             <ToggleButtonGroup size="small" value={mapInteraction} exclusive onChange={handleChange}>
                 <ToggleButton key={0} value="Select">
-                    <CenterFocusWeakIcon/>
+                    <CenterFocusStrongIcon/>
                 </ToggleButton>
                 <ToggleButton key={1} value="Point">
-                    <TripOriginIcon/>
+                    <RoomIcon/>
                 </ToggleButton>
                 <ToggleButton key={2} value="Polygon">
                     <CategoryIcon/>
+                </ToggleButton>
+                <ToggleButton key={3} value="Circle">
+                    <FiberManualRecordIcon/>
                 </ToggleButton>
             </ToggleButtonGroup>
         </FormControl>

--- a/src/components/MapInteractionsBar.tsx
+++ b/src/components/MapInteractionsBar.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import CenterFocusWeakIcon from '@material-ui/icons/CenterFocusWeak';
+import TripOriginIcon from '@material-ui/icons/TripOrigin';
+import FormControl from '@material-ui/core/FormControl';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+
+import { WithLocale } from '../util/lang';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+
+
+const useStyles = makeStyles(theme => ({
+        formControl: {
+            marginTop: theme.spacing(1.5),
+            marginRight: theme.spacing(2),
+        },
+    }
+));
+
+interface MapInteractionsBarProps extends WithLocale {
+    mapInteraction: string;
+    setMapInteraction: (interaction: string) => void;
+}
+
+export default function MapInteractionsBar({mapInteraction, setMapInteraction}: MapInteractionsBarProps) {
+    const classes = useStyles();
+
+    function handleChange(event: React.MouseEvent<HTMLElement>, value: any) {
+        setMapInteraction(value);
+    }
+
+    return (
+        <FormControl className={classes.formControl}>
+            <ToggleButtonGroup size="small" value={mapInteraction} exclusive onChange={handleChange}>
+                <ToggleButton key={0} value="Select">
+                    <CenterFocusWeakIcon/>
+                </ToggleButton>
+                <ToggleButton key={1} value="Point">
+                    <TripOriginIcon/>
+                </ToggleButton>
+            </ToggleButtonGroup>
+        </FormControl>
+    );
+}

--- a/src/components/MapInteractionsBar.tsx
+++ b/src/components/MapInteractionsBar.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import CenterFocusWeakIcon from '@material-ui/icons/CenterFocusWeak';
 import TripOriginIcon from '@material-ui/icons/TripOrigin';
+import CategoryIcon from '@material-ui/icons/Category';
 import FormControl from '@material-ui/core/FormControl';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 
 import { WithLocale } from '../util/lang';
 import makeStyles from '@material-ui/core/styles/makeStyles';
+import { MapInteraction } from "../states/controlState";
 
 
 const useStyles = makeStyles(theme => ({
@@ -25,8 +27,12 @@ interface MapInteractionsBarProps extends WithLocale {
 export default function MapInteractionsBar({mapInteraction, setMapInteraction}: MapInteractionsBarProps) {
     const classes = useStyles();
 
-    function handleChange(event: React.MouseEvent<HTMLElement>, value: any) {
-        setMapInteraction(value);
+    function handleChange(event: React.MouseEvent<HTMLElement>, value: MapInteraction | null) {
+        if (value !== null) {
+            setMapInteraction(value);
+        } else {
+            setMapInteraction('Select');
+        }
     }
 
     return (
@@ -37,6 +43,9 @@ export default function MapInteractionsBar({mapInteraction, setMapInteraction}: 
                 </ToggleButton>
                 <ToggleButton key={1} value="Point">
                     <TripOriginIcon/>
+                </ToggleButton>
+                <ToggleButton key={2} value="Polygon">
+                    <CategoryIcon/>
                 </ToggleButton>
             </ToggleButtonGroup>
         </FormControl>

--- a/src/components/PlaceSelect.tsx
+++ b/src/components/PlaceSelect.tsx
@@ -32,7 +32,7 @@ interface PlaceSelectProps extends WithStyles<typeof styles>, WithLocale {
     places: Place[];
     placeLabels: string[];
     selectPlace: (placeId: string | null, dataset: Dataset[], userPlaceGroup: PlaceGroup) => void;
-    removeUserPlace: (placeId: string) => void;
+    removeUserPlace: (placeId: string, places: Place[]) => void;
 }
 
 class PlaceSelect extends React.Component<PlaceSelectProps> {
@@ -42,9 +42,9 @@ class PlaceSelect extends React.Component<PlaceSelectProps> {
     };
 
     handleRemoveButtonClick = (event: React.MouseEvent<HTMLElement>) => {
-        const {removeUserPlace, selectedPlaceId} = this.props;
+        const {removeUserPlace, selectedPlaceId, places} = this.props;
         if (selectedPlaceId !== null) {
-            removeUserPlace(selectedPlaceId);
+            removeUserPlace(selectedPlaceId, places);
         }
     };
 

--- a/src/components/PlaceSelect.tsx
+++ b/src/components/PlaceSelect.tsx
@@ -31,14 +31,14 @@ interface PlaceSelectProps extends WithStyles<typeof styles>, WithLocale {
     selectedPlaceId: string | null;
     places: Place[];
     placeLabels: string[];
-    selectPlace: (placeId: string | null, dataset: Dataset[], userPlaceGroup: PlaceGroup) => void;
+    selectPlace: (placeId: string | null, places: Place[], showInMap: boolean) => void;
     removeUserPlace: (placeId: string, places: Place[]) => void;
 }
 
 class PlaceSelect extends React.Component<PlaceSelectProps> {
 
     handlePlaceChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        this.props.selectPlace(event.target.value || null, this.props.datasets, this.props.userPlaceGroup);
+        this.props.selectPlace(event.target.value || null, this.props.places, true);
     };
 
     handleRemoveButtonClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/src/components/TimePlayer.tsx
+++ b/src/components/TimePlayer.tsx
@@ -21,7 +21,6 @@ const styles = (theme: Theme) => createStyles(
     {
         formControl: {
             marginTop: theme.spacing(1),
-            marginLeft: theme.spacing(1),
             marginRight: theme.spacing(1),
         },
     }

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -27,7 +27,7 @@ import {
     USER_PLACES_COLORS
 } from '../config';
 import { WithLocale } from '../util/lang';
-import { PlaceInfo } from '../model/place';
+import { Place, PlaceInfo } from '../model/place';
 
 
 const styles = (theme: Theme) => createStyles(
@@ -95,6 +95,9 @@ interface TimeSeriesChartProps extends WithStyles<typeof styles>, WithLocale {
     removeTimeSeriesGroup?: (id: string) => void;
 
     placeInfos?: { [placeId: string]: PlaceInfo };
+
+    selectPlace: (placeId: string | null, places: Place[], showInMap: boolean) => void;
+    places: Place[];
 }
 
 interface TimeSeriesChartState {
@@ -304,11 +307,12 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
     };
 
     readonly handleTimeSeriesClick = (timeSeriesGroupId: string, timeSeriesIndex: number, timeSeries: TimeSeries) => {
-        const {selectTimeSeries} = this.props;
+        const {selectTimeSeries, selectPlace, places} = this.props;
         console.log('handleTimeSeriesClick:', timeSeriesGroupId, timeSeriesIndex, timeSeries);
         if (!!selectTimeSeries) {
             selectTimeSeries(timeSeriesGroupId, timeSeriesIndex, timeSeries);
         }
+        selectPlace(timeSeries.source.placeId, places, true);
     };
 
     readonly handleMouseDown = (event: any) => {

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -10,7 +10,7 @@ import {
     Legend,
     AxisDomain,
     TooltipPayload,
-    ReferenceArea, ReferenceLine, TooltipProps, ErrorBar
+    ReferenceArea, ReferenceLine, TooltipProps, ErrorBar, DotProps
 } from 'recharts';
 import { Theme, createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
@@ -27,7 +27,7 @@ import {
     USER_PLACES_COLORS
 } from '../config';
 import { WithLocale } from '../util/lang';
-import { PlaceInfo } from "../model/place";
+import { PlaceInfo } from '../model/place';
 
 
 const styles = (theme: Theme) => createStyles(
@@ -169,6 +169,7 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
                     }
                 }
             });
+            const shadedLineColor = USER_PLACES_COLORS[lineColor][strokeShade];
             let errorBar;
             if (showErrorBars && hasErrorBars) {
                 errorBar = (
@@ -176,7 +177,7 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
                         dataKey="uncertainty"
                         width={4}
                         strokeWidth={1}
-                        stroke={USER_PLACES_COLORS[lineColor][strokeShade]}
+                        stroke={shadedLineColor}
                     />
                 );
             }
@@ -188,9 +189,9 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
                     unit={source.variableUnits}
                     data={data}
                     dataKey="average"
-                    dot={true}
-                    activeDot={true}
-                    stroke={showPointsOnly ? '#00000000' : USER_PLACES_COLORS[lineColor][strokeShade]}
+                    dot={<CustomizedDot radius={4} stroke={shadedLineColor} fill={'white'} strokeWidth={3}/>}
+                    activeDot={<CustomizedDot radius={4} stroke={shadedLineColor} fill={'yellow'} strokeWidth={3}/>}
+                    stroke={showPointsOnly ? '#00000000' :shadedLineColor}
                     strokeWidth={3 * (ts.dataProgress || 1)}
                     isAnimationActive={ts.dataProgress === 1.0}
                     onClick={() => this.handleTimeSeriesClick(timeSeriesGroup.id, i, ts)}
@@ -420,4 +421,33 @@ class _CustomTooltip extends React.PureComponent<_CustomTooltipProps> {
 
 const CustomTooltip = withStyles(styles)(_CustomTooltip);
 
+interface CustomizedDotProps extends DotProps {
+    radius: number;
+    stroke: string;
+    strokeWidth: number;
+    fill: string;
+}
 
+
+const CustomizedDot = (props: CustomizedDotProps) => {
+
+    const {cx, cy, radius, stroke, fill, strokeWidth} = props;
+
+    const vpSize = 1024;
+    const totalRadius = radius + 0.5 * strokeWidth;
+    const totalDiameter = 2 * totalRadius;
+
+    const r = Math.floor(100 * radius / totalDiameter + 0.5) + '%';
+    const sw = Math.floor(100 * strokeWidth / totalDiameter + 0.5) + '%';
+
+    // noinspection SuspiciousTypeOfGuard
+    if (typeof cx === 'number' && typeof cy === 'number') {
+        return (
+            <svg x={cx - totalRadius} y={cy - totalRadius} width={totalDiameter} height={totalDiameter}
+                 viewBox={`0 0 ${vpSize} ${vpSize}`}>
+                <circle cx='50%' cy='50%' r={r} strokeWidth={sw} stroke={stroke} fill={fill}/>
+            </svg>
+        );
+    }
+    return null;
+};

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -136,15 +136,15 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
             if (placeInfos) {
                 const placeInfo = placeInfos[source.placeId];
                 if (placeInfo) {
-                    const {place, placeLabel} = placeInfo;
+                    const {place, label, color} = placeInfo;
                     if (place.geometry.type === 'Point') {
                         const lon = place.geometry.coordinates[0];
                         const lat = place.geometry.coordinates[1];
-                        lineName += ` (${placeLabel}: ${lat.toFixed(5)},${lon.toFixed(5)})`;
+                        lineName += ` (${label}: ${lat.toFixed(5)},${lon.toFixed(5)})`;
                     } else {
-                        lineName += ` (${placeLabel})`;
+                        lineName += ` (${label})`;
                     }
-                    lineColor = (place.properties || {}) ['color'] || lineColor;
+                    lineColor = color;
                 }
             }
 
@@ -175,7 +175,7 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
                     <ErrorBar
                         dataKey="uncertainty"
                         width={4}
-                        strokeWidth={2}
+                        strokeWidth={1}
                         stroke={USER_PLACES_COLORS[lineColor][strokeShade]}
                     />
                 );

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -196,7 +196,7 @@ class TimeSeriesChart extends React.Component<TimeSeriesChartProps, TimeSeriesCh
                     data={data}
                     dataKey="average"
                     dot={<CustomizedDot radius={4} stroke={shadedLineColor} fill={'white'} strokeWidth={3}/>}
-                    activeDot={<CustomizedDot radius={4} stroke={shadedLineColor} fill={'yellow'} strokeWidth={3}/>}
+                    activeDot={<CustomizedDot radius={4} stroke={'white'} fill={shadedLineColor} strokeWidth={3}/>}
                     stroke={showPointsOnly ? '#00000000' :shadedLineColor}
                     strokeWidth={3 * (ts.dataProgress || 1)}
                     isAnimationActive={ts.dataProgress === 1.0}

--- a/src/components/TimeSeriesCharts.tsx
+++ b/src/components/TimeSeriesCharts.tsx
@@ -58,14 +58,13 @@ class TimeSeriesCharts extends React.Component<TimeSeriesChartsProps> {
             removeTimeSeriesGroup, showPointsOnly, showErrorBars,
             placeInfos, places, selectPlace
         } = this.props;
-        const charts = timeSeriesGroups.map(timeSeriesGroup => {
-            const charts = timeSeriesGroups.map((timeSeriesGroup: TimeSeriesGroup) => {
-                const completed = timeSeriesGroup.timeSeriesArray.map(item => (
-                                                                          item.dataProgress ? 100 * item.dataProgress : 0
-                                                                      )
-                );
 
-                return (
+        const charts = timeSeriesGroups.map((timeSeriesGroup: TimeSeriesGroup) => {
+            const completed = timeSeriesGroup.timeSeriesArray.map(item => (
+                item.dataProgress ? 100 * item.dataProgress : 0
+            ));
+
+            return (
                 <TimeSeriesChart
                     key={timeSeriesGroup.id}
                     locale={locale}
@@ -82,38 +81,14 @@ class TimeSeriesCharts extends React.Component<TimeSeriesChartsProps> {
                     placeInfos={placeInfos}
                     places={places}
                     selectPlace={selectPlace}
-                />);
-        }
-        }
+                />
+            );
+        });
 
-        const charts = timeSeriesGroups.map((timeSeriesGroup: TimeSeriesGroup) => {
-                const completed = timeSeriesGroup.timeSeriesArray.map(item => (
-                        item.dataProgress ? 100 * item.dataProgress : 0
-                    )
-                );
-
-                return (
-                    <TimeSeriesChart
-                        key={timeSeriesGroup.id}
-                        locale={locale}
-                        timeSeriesGroup={timeSeriesGroup}
-                        selectedTime={selectedTime}
-
-                        selectedTimeRange={selectedTimeRange}
-                        dataTimeRange={dataTimeRange}
-                        selectTime={selectTime}
-                        selectTimeRange={selectTimeRange}
-                        removeTimeSeriesGroup={removeTimeSeriesGroup}
-                        completed={completed}
-                        showPointsOnly={showPointsOnly}
-                        showErrorBars={showErrorBars}
-                        placeInfos={placeInfos}
-                    />)
-            }
-        );
         if (charts.length === 0) {
             return null;
         }
+
         return (
             <div className={classes.chartContainer}>
                 <TimeRangeSlider

--- a/src/components/TimeSeriesCharts.tsx
+++ b/src/components/TimeSeriesCharts.tsx
@@ -5,7 +5,7 @@ import { Theme } from '@material-ui/core';
 import { WithLocale } from '../util/lang';
 import TimeSeriesChart from './TimeSeriesChart';
 import { Time, TimeRange, TimeSeriesGroup } from '../model/timeSeries';
-import { PlaceInfo } from "../model/place";
+import { Place, PlaceInfo } from "../model/place";
 import TimeRangeSlider from './TimeRangeSlider';
 
 
@@ -43,6 +43,8 @@ interface TimeSeriesChartsProps extends WithStyles<typeof styles>, WithLocale {
 
     removeTimeSeriesGroup?: (id: string) => void;
     placeInfos?: { [placeId: string]: PlaceInfo };
+    selectPlace: (placeId: string | null, places: Place[], showInMap: boolean) => void;
+    places: Place[];
 }
 
 class TimeSeriesCharts extends React.Component<TimeSeriesChartsProps> {
@@ -54,7 +56,7 @@ class TimeSeriesCharts extends React.Component<TimeSeriesChartsProps> {
             selectedTime, selectedTimeRange,
             dataTimeRange, selectTime, selectTimeRange,
             removeTimeSeriesGroup, showPointsOnly, showErrorBars,
-            placeInfos
+            placeInfos, places, selectPlace
         } = this.props;
         const charts = timeSeriesGroups.map(timeSeriesGroup => (
             <TimeSeriesChart
@@ -70,6 +72,8 @@ class TimeSeriesCharts extends React.Component<TimeSeriesChartsProps> {
                 showPointsOnly={showPointsOnly}
                 showErrorBars={showErrorBars}
                 placeInfos={placeInfos}
+                places={places}
+                selectPlace={selectPlace}
             />)
         );
         if (charts.length === 0) {

--- a/src/components/Viewer.test.tsx
+++ b/src/components/Viewer.test.tsx
@@ -5,6 +5,6 @@ import Viewer from './Viewer';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
-    ReactDOM.render(<Viewer userPlaceGroup={{type: 'FeatureCollection', id: 'user', title: '', features: []}}/>, div);
+    ReactDOM.render(<Viewer userPlaceGroup={{type: 'FeatureCollection', id: 'user', title: '', features: []}} places={[]}/>, div);
     ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/components/Viewer.test.tsx
+++ b/src/components/Viewer.test.tsx
@@ -5,6 +5,6 @@ import Viewer from './Viewer';
 
 it('renders without crashing', () => {
     const div = document.createElement('div');
-    ReactDOM.render(<Viewer userPlaceGroup={{type: 'FeatureCollection', id: 'user', title: '', features: []}} places={[]}/>, div);
+    ReactDOM.render(<Viewer userPlaceGroup={{type: 'FeatureCollection', id: 'user', title: '', features: []}} places={[]} mapInteraction={'Select'}/>, div);
     ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -14,6 +14,7 @@ import { Draw, DrawEvent } from './ol/interaction/Draw';
 import { Vector } from './ol/layer/Vector';
 import { OSMBlackAndWhite } from './ol/layer/Tile';
 import { Control } from './ol/control/Control';
+import { Select, SelectEvent } from './ol/interaction/Select';
 
 
 interface ViewerProps {
@@ -82,6 +83,10 @@ class Viewer extends React.Component<ViewerProps> {
         return true;
     };
 
+    handleSelect = (event: SelectEvent) => {
+        console.log('handleSelect: ', event);
+    };
+
     handleMapRef = (map: ol.Map | null) => {
         this.map = map;
     };
@@ -116,7 +121,8 @@ class Viewer extends React.Component<ViewerProps> {
         const variableLayer = this.props.variableLayer;
         const placeGroupLayers = this.props.placeGroupLayers;
         const colorBarLegend = this.props.colorBarLegend;
-        const drawMode = this.props.drawMode;
+        //const drawMode = this.props.drawMode;
+        const drawMode = false;
         const draw = drawMode ?
                      <Draw
                          id="draw"
@@ -153,6 +159,7 @@ class Viewer extends React.Component<ViewerProps> {
                     </Layers>
                     {placeGroupLayers}
                     {draw}
+                    <Select onSelect={this.handleSelect}/>
                     {colorBarControl}
                 </Map>
             </ErrorBoundary>

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -160,7 +160,6 @@ class Viewer extends React.Component<ViewerProps> {
             if (selectedPlaceIdCurr) {
                 const selectedFeature = findFeatureById(this.map!, selectedPlaceIdCurr);
                 if (selectedFeature) {
-                    console.log("Viewer.componentDidUpdate: selectedFeature =", selectedFeature);
                     // We clone so feature so we can set a new ID and clear the style, so the selection
                     // layer style is used instead as default.
                     const displayFeature = selectedFeature.clone();

--- a/src/components/ol/Map.tsx
+++ b/src/components/ol/Map.tsx
@@ -102,7 +102,6 @@ export class Map extends React.Component<MapProps, MapState> {
         if (this.props.isStale) {
             const mapObject = this.contextValue.mapObjects[id];
             if (mapObject && mapObject['addControl'] && mapObject['addLayer'] && mapObject['setTarget']) {
-                console.log('Map.componentDidMount: reusing stale map');
                 map = mapObject as ol.Map;
                 map.setTarget(mapDiv);
             }

--- a/src/components/ol/interaction/Draw.tsx
+++ b/src/components/ol/interaction/Draw.tsx
@@ -8,6 +8,7 @@ export type DrawListener = ((event: DrawEvent) => void) | ((event: DrawEvent) =>
 
 interface DrawProps extends MapComponentProps, olx.interaction.DrawOptions {
     layerId?: string;
+    active?: boolean;
     onDrawStart?: DrawListener;
     onDrawEnd?: DrawListener;
 }
@@ -16,15 +17,23 @@ export class Draw extends MapComponent<ol.interaction.Draw, DrawProps> {
 
     addMapObject(map: ol.Map): ol.interaction.Draw {
         const draw = new ol.interaction.Draw(this.getOptions());
+        let active = !!this.props.active;
+        draw.setActive(active);
         map.addInteraction(draw);
-        this.listen(draw, this.props);
+        if (active) {
+            this.listen(draw, this.props);
+        }
         return draw;
     }
 
     updateMapObject(map: ol.Map, draw: ol.interaction.Draw, prevProps: Readonly<DrawProps>): ol.interaction.Draw {
         draw.setProperties(this.getOptions());
+        let active = !!this.props.active;
+        draw.setActive(active);
         this.unlisten(draw, prevProps);
-        this.listen(draw, this.props);
+        if (active) {
+            this.listen(draw, this.props);
+        }
         return draw;
     }
 
@@ -36,6 +45,7 @@ export class Draw extends MapComponent<ol.interaction.Draw, DrawProps> {
     getOptions(): olx.interaction.DrawOptions {
         let options = super.getOptions();
         delete options['layerId'];
+        delete options['active'];
         delete options['onDrawStart'];
         delete options['onDrawEnd'];
         const layerId = this.props.layerId;

--- a/src/components/ol/interaction/Draw.tsx
+++ b/src/components/ol/interaction/Draw.tsx
@@ -36,6 +36,8 @@ export class Draw extends MapComponent<ol.interaction.Draw, DrawProps> {
     getOptions(): olx.interaction.DrawOptions {
         let options = super.getOptions();
         delete options['layerId'];
+        delete options['onDrawStart'];
+        delete options['onDrawEnd'];
         const layerId = this.props.layerId;
         if (layerId && !options.source) {
             const vectorLayer = this.getMapObject(layerId);

--- a/src/components/ol/interaction/Select.tsx
+++ b/src/components/ol/interaction/Select.tsx
@@ -59,8 +59,10 @@ export class Select extends MapComponent<ol.interaction.Select, SelectProps> {
     private updateSelection(select: ol.interaction.Select) {
         if (this.context.map && this.props.selectedFeaturesIds) {
             const selectedFeatures = findFeaturesByIds(this.context.map!, this.props.selectedFeaturesIds).filter(f => f !== null) as ol.Feature[];
-            console.log("Select: ", this.props.selectedFeaturesIds, selectedFeatures);
+            // console.log("Select: ", this.props.selectedFeaturesIds, selectedFeatures);
             if (selectedFeatures.length > 0) {
+                // TODO (forman): must get around OpenLayers weirdness here: Selection style function is called only
+                // if a feature does not have any styles set.
                 select.getFeatures().clear();
                 select.getFeatures().extend(selectedFeatures);
                 this.context.map.render();

--- a/src/components/ol/interaction/Select.tsx
+++ b/src/components/ol/interaction/Select.tsx
@@ -1,0 +1,115 @@
+import * as ol from 'openlayers';
+import { olx } from 'openlayers';
+
+import { MapComponent, MapComponentProps } from '../MapComponent';
+
+export type SelectEvent = ol.interaction.Select.Event;
+export type SelectListener = ((event: SelectEvent) => void) | ((event: SelectEvent) => boolean);
+
+interface SelectProps extends MapComponentProps, olx.interaction.SelectOptions {
+    onSelect?: SelectListener;
+}
+
+
+export class Select extends MapComponent<ol.interaction.Select, SelectProps> {
+
+    addMapObject(map: ol.Map): ol.interaction.Select {
+        const getOptions = new ol.interaction.Select({style: styleFunction, ...this.getOptions()});
+        map.addInteraction(getOptions);
+        this.listen(getOptions, this.props);
+        return getOptions;
+    }
+
+    updateMapObject(map: ol.Map, select: ol.interaction.Select, prevProps: Readonly<SelectProps>): ol.interaction.Select {
+        select.setProperties(this.getOptions());
+        this.unlisten(select, prevProps);
+        this.listen(select, this.props);
+        return select;
+    }
+
+    removeMapObject(map: ol.Map, select: ol.interaction.Select): void {
+        this.unlisten(select, this.props);
+        map.removeInteraction(select);
+    }
+
+    getOptions(): olx.interaction.DrawOptions {
+        let options = super.getOptions();
+        delete options['onSelect'];
+        return options;
+    }
+
+    private listen(select: ol.interaction.Select, props: Readonly<SelectProps>) {
+        const {onSelect} = props;
+        if (onSelect) {
+            select.on('select', onSelect);
+        }
+    }
+
+    private unlisten(select: ol.interaction.Select, props: Readonly<SelectProps>) {
+        const {onSelect} = props;
+        if (onSelect) {
+            select.un('select', onSelect);
+        }
+    }
+}
+
+
+const OL_DEFAULT_FILL = new ol.style.Fill({
+                                              color: [255, 255, 255, 0.4]
+                                          });
+const OL_DEFAULT_STROKE_WIDTH = 1.25;
+const OL_DEFAULT_STROKE = new ol.style.Stroke({
+                                                  color: '#3399CC',
+                                                  width: OL_DEFAULT_STROKE_WIDTH
+                                              });
+const OL_DEFAULT_CIRCLE_RADIUS = 5;
+
+
+
+const SELECT_STROKE_COLOR: ol.Color = [255, 255, 0, 0.7];
+
+
+
+function styleFunction(feature: (ol.Feature | ol.render.Feature), resolution: number) {
+    console.log('style func: properties: ', feature.getProperties());
+    console.log('style func: style: ', (feature as any).getStyle());
+
+    let defaultFill = OL_DEFAULT_FILL;
+    let defaultStroke = OL_DEFAULT_STROKE;
+    let defaultRadius = OL_DEFAULT_CIRCLE_RADIUS;
+
+    if (typeof feature['getStyle'] === 'function') {
+        let styleObj = feature['getStyle']();
+        if (Array.isArray(styleObj)) {
+            styleObj = styleObj[0];
+        } else if (typeof styleObj === 'function') {
+            styleObj = styleObj(feature);
+        }
+        if (styleObj
+            && typeof styleObj['getFill'] === 'function'
+            && typeof styleObj['getStroke'] === 'function'
+            &&  typeof styleObj['getImage'] === 'function') {
+            const defaultStyle = styleObj as ol.style.Style;
+            const imageObj = defaultStyle.getImage();
+            if (imageObj
+                && typeof imageObj['getFill'] === 'function'
+                && typeof imageObj['getStroke'] === 'function'
+                && typeof imageObj['getRadius'] === 'function') {
+                const circle = imageObj as ol.style.Circle;
+                defaultFill = circle.getFill();
+                defaultStroke = circle.getStroke();
+                defaultRadius = circle.getRadius();
+            } else {
+                defaultFill = defaultStyle.getFill();
+                defaultStroke = defaultStyle.getStroke();
+            }
+        }
+    }
+
+    const styleOptions = {fill: defaultFill, stroke: new ol.style.Stroke({width: 1.5 *  defaultStroke.getWidth(), color: SELECT_STROKE_COLOR})};
+    if (feature.getGeometry().getType() === 'Point') {
+        return new ol.style.Style({image: new ol.style.Circle({radius: 1.5 * defaultRadius, ...styleOptions})});
+    } else {
+        return new ol.style.Style(styleOptions);
+    }
+}

--- a/src/components/ol/layer/Tile.tsx
+++ b/src/components/ol/layer/Tile.tsx
@@ -34,8 +34,10 @@ export class Tile extends MapComponent<ol.layer.Tile, TileProps> {
     addMapObject(map: ol.Map): ol.layer.Tile {
         const layer = new ol.layer.Tile(this.props);
 
-        // Attempt to avoid image smoothing so crisp image pixels are drawn.
+        // TODO (forman): Issue #86: The following is an attempt to avoid image smoothing
+        //                so crisp image pixels are drawn. But it still doesn't work.
         // See https://stackoverflow.com/questions/54083424/preventing-smoothing-of-tileimage-layer
+        // See https://stackoverflow.com/questions/35875270/turn-off-image-smoothing-in-openlayers-3
         // See https://openlayers.org/en/latest/examples/layer-spy.html
         //
         layer.on('precompose', (event: any) => {

--- a/src/connected/ControlBar.tsx
+++ b/src/connected/ControlBar.tsx
@@ -7,6 +7,7 @@ import DatasetSelect from './DatasetSelect';
 import VariableSelect from './VariableSelect';
 import PlaceGroupsSelect from './PlaceGroupsSelect';
 import PlaceSelect from './PlaceSelect';
+import MapInteractionsBar from "./MapInteractionsBar";
 import TimeSelect from './TimeSelect';
 import TimeSlider from './TimeSlider';
 import TimePlayer from "./TimePlayer";
@@ -28,6 +29,7 @@ class _ControlBar extends React.Component {
                 <VariableSelect/>
                 <PlaceGroupsSelect/>
                 <PlaceSelect/>
+                <MapInteractionsBar/>
                 <TimeSelect/>
                 <TimePlayer/>
                 <TimeSlider/>

--- a/src/connected/MapInteractionsBar.tsx
+++ b/src/connected/MapInteractionsBar.tsx
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+
+import MapInteractionsBar from '../components/MapInteractionsBar';
+import { AppState } from '../states/appState';
+import { setMapInteraction } from '../actions/controlActions';
+
+const mapStateToProps = (state: AppState) => {
+    return {
+        mapInteraction: state.controlState.mapInteraction,
+    };
+};
+
+const mapDispatchToProps = {
+    setMapInteraction,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(MapInteractionsBar);

--- a/src/connected/TimeSeriesCharts.tsx
+++ b/src/connected/TimeSeriesCharts.tsx
@@ -3,8 +3,12 @@ import { connect } from 'react-redux';
 import { AppState } from '../states/appState';
 import TimeSeriesCharts from '../components/TimeSeriesCharts';
 import { removeTimeSeriesGroup } from "../actions/dataActions";
-import { selectTime, selectTimeRange } from "../actions/controlActions";
-import { selectedDatasetTimeRangeSelector, timeSeriesPlaceInfosSelector } from '../selectors/controlSelectors';
+import { selectPlace, selectTime, selectTimeRange } from "../actions/controlActions";
+import {
+    selectedDatasetTimeRangeSelector,
+    selectedPlaceGroupPlacesSelector,
+    timeSeriesPlaceInfosSelector
+} from '../selectors/controlSelectors';
 
 
 const mapStateToProps = (state: AppState) => {
@@ -17,13 +21,15 @@ const mapStateToProps = (state: AppState) => {
         showPointsOnly: state.controlState.showTimeSeriesPointsOnly,
         showErrorBars: state.controlState.showTimeSeriesErrorBars,
         placeInfos: timeSeriesPlaceInfosSelector(state),
+        places: selectedPlaceGroupPlacesSelector(state),
     }
 };
 
 const mapDispatchToProps = {
     selectTime,
     selectTimeRange,
-    removeTimeSeriesGroup
+    removeTimeSeriesGroup,
+    selectPlace,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeSeriesCharts);

--- a/src/connected/Viewer.tsx
+++ b/src/connected/Viewer.tsx
@@ -20,6 +20,7 @@ const mapStateToProps = (state: AppState) => {
         userPlaceGroup: userPlaceGroupSelector(state),
         drawMode: state.controlState.selectedDrawMode,
         flyTo: state.controlState.flyTo,
+        selectedPlaceId: state.controlState.selectedPlaceId,
     }
 };
 

--- a/src/connected/Viewer.tsx
+++ b/src/connected/Viewer.tsx
@@ -4,11 +4,12 @@ import { AppState } from '../states/appState';
 import {
     selectedColorBarLegendSelector,
     selectedDatasetPlaceGroupLayersSelector,
-    selectedDatasetVariableLayerSelector
+    selectedDatasetVariableLayerSelector, selectedPlaceGroupPlacesSelector
 } from '../selectors/controlSelectors';
 import { addUserPlace } from '../actions/dataActions';
 import Viewer from '../components/Viewer';
 import { userPlaceGroupSelector } from "../selectors/dataSelectors";
+import { selectPlace } from "../actions/controlActions";
 
 
 const mapStateToProps = (state: AppState) => {
@@ -18,14 +19,16 @@ const mapStateToProps = (state: AppState) => {
         placeGroupLayers: selectedDatasetPlaceGroupLayersSelector(state),
         colorBarLegend: selectedColorBarLegendSelector(state),
         userPlaceGroup: userPlaceGroupSelector(state),
-        drawMode: state.controlState.selectedDrawMode,
+        mapInteraction: state.controlState.mapInteraction,
         flyTo: state.controlState.flyTo,
         selectedPlaceId: state.controlState.selectedPlaceId,
+        places: selectedPlaceGroupPlacesSelector(state),
     }
 };
 
 const mapDispatchToProps = {
     addUserPlace,
+    selectPlace,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Viewer);

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -1,5 +1,5 @@
 import { Variable } from './variable';
-import { findPlaceInPlaceGroup, findPlaceInPlaceGroups, Place, PlaceGroup } from './place';
+import { PlaceGroup } from './place';
 import { TimeRange } from './timeSeries';
 import {
     assertArrayNotEmpty,
@@ -44,24 +44,6 @@ export function findDataset(datasets: Dataset[], selectedDatasetId: string | nul
 
 export function findDatasetVariable(dataset: Dataset, variableName: string | null): Variable | null {
     return (variableName && dataset.variables.find(variable => variable.name === variableName)) || null;
-}
-
-export function findDatasetPlace(dataset: Dataset, placeId: string | null): Place | null {
-    return (placeId && dataset.placeGroups && findPlaceInPlaceGroups(dataset.placeGroups, placeId)) || null;
-}
-
-export function findDatasetOrUserPlace(datasets: Dataset[], userPlaceGroup: PlaceGroup, placeId: string): Place | null {
-    const place = findPlaceInPlaceGroup(userPlaceGroup, placeId);
-    if (place) {
-        return place;
-    }
-    for (let dataset of datasets) {
-        const place = findDatasetPlace(dataset, placeId);
-        if (place !== null) {
-            return place;
-        }
-    }
-    return null;
 }
 
 export function getDatasetTimeDimension(dataset: Dataset): TimeDimension {

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -1,6 +1,6 @@
 import * as ol from 'openlayers';
 
-import { findDataset, findDatasetVariable, getDatasetTimeRange, findDatasetOrUserPlace } from '../model/dataset';
+import { findDataset, findDatasetVariable, getDatasetTimeRange } from '../model/dataset';
 import { ControlState, newControlState } from '../states/controlState';
 import {
     SELECT_DATASET,
@@ -18,7 +18,7 @@ import {
     OPEN_DIALOG,
     CLOSE_DIALOG,
     INC_SELECTED_TIME,
-    UPDATE_SETTINGS,
+    UPDATE_SETTINGS, SET_MAP_INTERACTION,
 } from '../actions/controlActions';
 import { CONFIGURE_SERVERS, DataAction, ADD_USER_PLACE, REMOVE_USER_PLACE } from "../actions/dataActions";
 import { I18N } from "../config";
@@ -73,9 +73,9 @@ export function controlReducer(state: ControlState, action: ControlAction | Data
         case SELECT_PLACE: {
             const selectedPlaceId = action.selectedPlaceId;
             let flyTo = state.flyTo;
-            if (selectedPlaceId) {
-                const place = findDatasetOrUserPlace(action.datasets, action.userPlaceGroup, selectedPlaceId);
-                if (place !== null) {
+            if (selectedPlaceId && action.showInMap) {
+                const place = action.places.find(p => p.id === selectedPlaceId);
+                if (place) {
                     if (place.bbox && place.bbox.length === 4) {
                         flyTo = place.bbox as [number, number, number, number];
                     } else if (place.geometry && SIMPLE_GEOMETRY_TYPES.includes(place.geometry.type)) {
@@ -194,6 +194,12 @@ export function controlReducer(state: ControlState, action: ControlAction | Data
                 };
             }
             return state;
+        }
+        case SET_MAP_INTERACTION: {
+            return {
+                ...state,
+                mapInteraction: action.mapInteraction
+            };
         }
         case ADD_ACTIVITY: {
             return {

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -20,7 +20,7 @@ import {
     INC_SELECTED_TIME,
     UPDATE_SETTINGS,
 } from '../actions/controlActions';
-import { CONFIGURE_SERVERS, DataAction, ADD_USER_PLACE } from "../actions/dataActions";
+import { CONFIGURE_SERVERS, DataAction, ADD_USER_PLACE, REMOVE_USER_PLACE } from "../actions/dataActions";
 import { I18N } from "../config";
 import { AppState } from "../states/appState";
 import { selectedTimeIndexSelector, timeCoordinatesSelector } from "../selectors/controlSelectors";
@@ -175,6 +175,25 @@ export function controlReducer(state: ControlState, action: ControlAction | Data
                 selectedPlaceGroupIds,
                 selectedPlaceId: action.id,
             };
+        }
+        case REMOVE_USER_PLACE: {
+            const {id, places} = action;
+            if (id === state.selectedPlaceId) {
+                let selectedPlaceId = null;
+                const index = places.findIndex(p => p.id === id);
+                if (index >= 0) {
+                    if (index < places.length - 1) {
+                        selectedPlaceId = places[index + 1].id;
+                    } else if (index > 0) {
+                        selectedPlaceId = places[index - 1].id;
+                    }
+                }
+                return {
+                    ...state,
+                    selectedPlaceId
+                };
+            }
+            return state;
         }
         case ADD_ACTIVITY: {
             return {

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -120,6 +120,13 @@
       "se": "Polygon"
     },
     {
+      "en": "Circle",
+      "de": "Kreis",
+      "it": "Cerchio",
+      "ro": "Cerc",
+      "se": "Cirkel"
+    },
+    {
       "en": "Multi",
       "de": "Multi",
       "it": "Multi",

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -113,6 +113,13 @@
       "se": "Punkt"
     },
     {
+      "en": "Polygon",
+      "de": "Polygon",
+      "it": "Poligono",
+      "ro": "Poligon",
+      "se": "Polygon"
+    },
+    {
       "en": "Multi",
       "de": "Multi",
       "it": "Multi",

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -163,10 +163,10 @@ export const timeSeriesPlaceInfosSelector = createSelector(
     placeGroupsSelector,
     (timeSeriesGroups: TimeSeriesGroup[], placeGroups: PlaceGroup[]): { [placeId: string]: PlaceInfo } => {
         const placeInfos = {};
-        forEachPlace(placeGroups, (placeGroup, place, placeLabel) => {
+        forEachPlace(placeGroups, (placeGroup, place, label, color) => {
             for (let timeSeriesGroup of timeSeriesGroups) {
                 if (timeSeriesGroup.timeSeriesArray.find(ts => ts.source.placeId === place.id)) {
-                    placeInfos[place.id] = {placeGroup, place, placeLabel};
+                    placeInfos[place.id] = {placeGroup, place, label, color};
                     break;
                 }
             }
@@ -180,8 +180,8 @@ export const selectedPlaceGroupPlaceLabelsSelector = createSelector(
     selectedPlaceGroupsSelector,
     (placeGroups: PlaceGroup[]): string[] => {
         const placeLabels: string[] = [];
-        forEachPlace(placeGroups, (placeGroup, place, placeLabel) => {
-            placeLabels.push(placeLabel);
+        forEachPlace(placeGroups, (placeGroup, place, label) => {
+            placeLabels.push(label);
         });
         return placeLabels;
     }

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -6,6 +6,7 @@ import { loadUserSettings } from './userSettings';
 export type TimeAnimationInterval = 250 | 500 | 1000 | 2500;
 export const TIME_ANIMATION_INTERVALS: TimeAnimationInterval[] = [250, 500, 1000, 2500];
 
+export type MapInteraction = 'Select' | 'Point' | 'Polygon';
 
 export interface ControlState {
     selectedDatasetId: string | null;
@@ -16,7 +17,6 @@ export interface ControlState {
     selectedServerId: string;
     selectedTime: Time | null;
     selectedTimeRange: TimeRange | null;
-    selectedDrawMode: ol.geom.GeometryType | null;
     timeSeriesUpdateMode: 'add' | 'replace';
     timeAnimationActive: boolean;
     timeAnimationInterval: TimeAnimationInterval;
@@ -28,7 +28,9 @@ export interface ControlState {
     locale: string;
     dialogOpen: { [dialogId: string]: boolean };
     legalAgreementAccepted: boolean;
+    mapInteraction: MapInteraction;
 }
+
 
 export function newControlState(): ControlState {
     const state: ControlState = {
@@ -40,7 +42,6 @@ export function newControlState(): ControlState {
         selectedServerId: VIEWER_DEFAULT_API_SERVER.id,
         selectedTime: null,
         selectedTimeRange: null,
-        selectedDrawMode: 'Point',
         timeSeriesUpdateMode: 'add',
         timeAnimationActive: false,
         timeAnimationInterval: 1000,
@@ -52,6 +53,7 @@ export function newControlState(): ControlState {
         locale: 'en',
         dialogOpen: {},
         legalAgreementAccepted: false,
+        mapInteraction: 'Point',
     };
     return loadUserSettings(state);
 }

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -6,7 +6,7 @@ import { loadUserSettings } from './userSettings';
 export type TimeAnimationInterval = 250 | 500 | 1000 | 2500;
 export const TIME_ANIMATION_INTERVALS: TimeAnimationInterval[] = [250, 500, 1000, 2500];
 
-export type MapInteraction = 'Select' | 'Point' | 'Polygon';
+export type MapInteraction = 'Select' | 'Point' | 'Polygon' | 'Circle';
 
 export interface ControlState {
     selectedDatasetId: string | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,6 +830,17 @@
   dependencies:
     "@babel/runtime" "^7.2.0"
 
+"@material-ui/lab@^4.0.0-alpha.25":
+  version "4.0.0-alpha.25"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.25.tgz#243ed39c3b26bcc1b545a32cc97aba53bae2c078"
+  integrity sha512-KaySMP6SLtPFalpFClcMK3sZO9UgzCzpFZ41UiESP0FvebORbH9NAD/TwYDyr+o2vghC+lzzRLRtr5HM3V8Mrg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.4.0"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    warning "^4.0.3"
+
 "@material-ui/pickers@^3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.2.4.tgz#be5dfcff71120de8c3711595d773ec3f2141b736"
@@ -2899,7 +2910,7 @@ closure-util@1.26.0:
     socket.io "2.0.4"
     temp "0.8.3"
 
-clsx@^1.0.2:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
@@ -11224,7 +11235,7 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^4.0.1:
+warning@^4.0.1, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   dependencies:


### PR DESCRIPTION
Note, this PR includes PR #85, check that one first.

In addition:

* Users can now draw polygons and circles and show respective time-series. (#32)
  In total there are now 4 new interactions with the map:
  - Select a geometry
  - Draw a point
  - Draw a geometry
  - Draw a circle 
* Improved selection of places:
  - If a place is selected in the list, it is zoomed to and highlighted in the map;
  - Places can now be selected in the map if the "Select" interaction is active;
  - Places are also selected if a time-series line is clicked.
    (However, that doesn't work nicely yet due to issues in the Recharts lib).
* Minor fixes:
  * Colors used for geometries in the map and for lines in the time-series charts are now exactly the same.
  * Time-series charts now have constant spacing

Closes #32