### PR TITLE
Forman xxx rgb tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Enhancements
 
+* Added a "RGB" switch to the app bar that is used to display the selected dataset's RGB layer, 
+  if any. Currently, RGB layers can only be configured through the xcube server. Later xcube viewer 
+  versions will allow users selecting three variables and their respective value ranges for normalisation.
 * Users can now login (and sign on) if the viewer is build with OAuth2 settings, if any, given 
   in a `.env.local` file (#22): 
   ```bash

--- a/src/actions/controlActions.tsx
+++ b/src/actions/controlActions.tsx
@@ -39,7 +39,7 @@ export interface SelectDataset {
 }
 
 export function selectDataset(selectedDatasetId: string | null, datasets: Dataset[], showInMap: boolean) {
-    return (dispatch: Dispatch<SelectDataset>, getState: () => AppState) => {
+    return (dispatch: Dispatch<SelectDataset>) => {
         dispatch(_selectDataset(selectedDatasetId, datasets));
         if (selectedDatasetId && showInMap) {
             dispatch(flyToDataset(selectedDatasetId) as any);
@@ -173,7 +173,7 @@ export interface SelectPlace {
 
 
 export function selectPlace(selectedPlaceId: string | null, places: Place[], showInMap: boolean) {
-    return (dispatch: Dispatch<SelectPlace>, getState: () => AppState) => {
+    return (dispatch: Dispatch<SelectPlace>) => {
         dispatch(_selectPlace(selectedPlaceId, places));
         if (showInMap && selectedPlaceId) {
             dispatch(flyToPlace(selectedPlaceId) as any);
@@ -183,6 +183,20 @@ export function selectPlace(selectedPlaceId: string | null, places: Place[], sho
 
 function _selectPlace(selectedPlaceId: string | null, places: Place[]): SelectPlace {
     return {type: SELECT_PLACE, selectedPlaceId, places};
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const SET_RGB_LAYER_VISIBILITY = 'SET_RGB_LAYER_VISIBILITY';
+export type SET_RGB_LAYER_VISIBILITY = typeof SET_RGB_LAYER_VISIBILITY;
+
+export interface SetRgbLayerVisibility {
+    type: SET_RGB_LAYER_VISIBILITY;
+    showRgbLayer: boolean;
+}
+
+export function setRgbLayerVisibility(showRgbLayer: boolean): SetRgbLayerVisibility {
+    return {type: SET_RGB_LAYER_VISIBILITY, showRgbLayer};
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -242,6 +256,8 @@ export function selectTimeRange(selectedTimeRange: TimeRange | null): SelectTime
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// TODO (forman): this action doesn't seem to be in use - remove!
 
 export const SELECT_TIME_SERIES_UPDATE_MODE = 'SELECT_TIME_SERIES_UPDATE_MODE';
 export type SELECT_TIME_SERIES_UPDATE_MODE = typeof SELECT_TIME_SERIES_UPDATE_MODE;
@@ -421,6 +437,7 @@ export type ControlAction =
     | SelectPlaceGroups
     | SelectPlace
     | SelectTime
+    | SetRgbLayerVisibility
     | IncSelectedTime
     | SelectTimeRange
     | SelectTimeSeriesUpdateMode

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -212,7 +212,7 @@ const DatasetInfoContent: React.FC<DatasetInfoContentProps> = ({isIn, viewMode, 
         content = (
             <CardContent2>
                 <KeyValueTable
-                    data={Object.getOwnPropertyNames(dataset.attrs).map(name => [name, dataset.attrs[name]])}
+                    data={Object.getOwnPropertyNames(dataset.attrs || {}).map(name => [name, dataset.attrs[name]])}
                 />
             </CardContent2>
         );
@@ -271,7 +271,7 @@ const VariableInfoContent: React.FC<VariableInfoContentProps> = ({isIn, viewMode
         content = (
             <CardContent2>
                 <KeyValueTable
-                    data={Object.getOwnPropertyNames(variable.attrs).map(name => [name, variable.attrs[name]])}
+                    data={Object.getOwnPropertyNames(variable.attrs || {}).map(name => [name, variable.attrs[name]])}
                 />
             </CardContent2>
         );

--- a/src/components/RgbSwitch.tsx
+++ b/src/components/RgbSwitch.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { withStyles, WithStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Switch from '@material-ui/core/Switch';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { RgbSchema } from '../model/dataset';
+
+import { WithLocale } from '../util/lang';
+import { I18N } from '../config';
+
+
+// noinspection JSUnusedLocalSymbols
+const styles = (theme: Theme) => createStyles(
+    {});
+
+interface RgbSwitchProps extends WithStyles<typeof styles>, WithLocale {
+    showRgbLayer: boolean;
+    rgbSchema: RgbSchema | null;
+    setRgbLayerVisibility: (showRgbLayer: boolean) => void;
+}
+
+const RgbSwitch: React.FC<RgbSwitchProps> = ({showRgbLayer, rgbSchema, setRgbLayerVisibility}) => {
+
+    const handleSwitchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setRgbLayerVisibility(event.target.checked);
+    };
+
+    return (
+        <FormControlLabel label={I18N.get('RGB')} control={
+            <Switch
+                color={'primary'}
+                checked={rgbSchema !== null ? showRgbLayer : false}
+                disabled={rgbSchema === null}
+                onChange={handleSwitchChange}
+            />
+        }/>
+    );
+};
+
+export default withStyles(styles)(RgbSwitch);
+

--- a/src/components/TimeSeriesModeSelect.tsx
+++ b/src/components/TimeSeriesModeSelect.tsx
@@ -6,6 +6,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { WithLocale } from '../util/lang';
 import { I18N } from '../config';
 
+// TODO (forman): this component doesn't seem to be in use - remove!
 
 const styles = (theme: Theme) => createStyles(
     {});

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -63,6 +63,7 @@ interface ViewerProps extends WithStyles<typeof styles> {
     mapId: string;
     mapInteraction: MapInteraction;
     baseMapLayer?: MapElement;
+    rgbLayer?: MapElement;
     variableLayer?: MapElement;
     placeGroupLayers?: MapElement;
     colorBarLegend?: MapElement;
@@ -78,6 +79,7 @@ const Viewer: React.FC<ViewerProps> = ({
                                            mapId,
                                            mapInteraction,
                                            baseMapLayer,
+                                           rgbLayer,
                                            variableLayer,
                                            placeGroupLayers,
                                            colorBarLegend,
@@ -187,6 +189,11 @@ const Viewer: React.FC<ViewerProps> = ({
                 {colorBarLegend}
             </Control>
         );
+    }
+
+    // TODO (forman): fix me! this is a workaround to avoid that rgbLayer is never visible.
+    if (rgbLayer !== null) {
+        variableLayer = rgbLayer;
     }
 
     return (

--- a/src/connected/ControlBar.tsx
+++ b/src/connected/ControlBar.tsx
@@ -6,6 +6,7 @@ import ControlBar from '../components/ControlBar';
 import { WithLocale } from '../util/lang';
 import DatasetSelect from './DatasetSelect';
 import VariableSelect from './VariableSelect';
+import RgbSwitch from './RgbSwitch';
 import PlaceGroupsSelect from './PlaceGroupsSelect';
 import PlaceSelect from './PlaceSelect';
 import MapInteractionsBar from './MapInteractionsBar';
@@ -35,6 +36,7 @@ const _ControlBar: React.FC<ControlBarProps> = (props) => {
         <ControlBar>
             <DatasetSelect/>
             <VariableSelect/>
+            <RgbSwitch/>
             <PlaceGroupsSelect/>
             <PlaceSelect/>
             <MapInteractionsBar/>

--- a/src/connected/RgbSwitch.tsx
+++ b/src/connected/RgbSwitch.tsx
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+
+import { AppState } from '../states/appState';
+import { setRgbLayerVisibility } from '../actions/controlActions';
+import { selectedDatasetRgbSchemaSelector } from '../selectors/controlSelectors';
+import RgbSwitch from '../components/RgbSwitch';
+
+
+const mapStateToProps = (state: AppState) => {
+    return {
+        locale: state.controlState.locale,
+        rgbSchema: selectedDatasetRgbSchemaSelector(state),
+        showRgbLayer: state.controlState.showRgbLayer,
+    };
+};
+
+const mapDispatchToProps = {
+    setRgbLayerVisibility,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(RgbSwitch);

--- a/src/connected/Viewer.tsx
+++ b/src/connected/Viewer.tsx
@@ -5,7 +5,9 @@ import { AppState } from '../states/appState';
 import {
     baseMapLayerSelector,
     selectedDatasetPlaceGroupLayersSelector,
-    selectedDatasetVariableLayerSelector, selectedPlaceGroupPlacesSelector
+    selectedDatasetRgbLayerSelector,
+    selectedDatasetVariableLayerSelector,
+    selectedPlaceGroupPlacesSelector
 } from '../selectors/controlSelectors';
 import { addUserPlace } from '../actions/dataActions';
 import Viewer from '../components/Viewer';
@@ -18,6 +20,7 @@ const mapStateToProps = (state: AppState) => {
     return {
         locale: state.controlState.locale,
         variableLayer: selectedDatasetVariableLayerSelector(state),
+        rgbLayer: selectedDatasetRgbLayerSelector(state),
         placeGroupLayers: selectedDatasetPlaceGroupLayersSelector(state),
         colorBarLegend: <ColorBarLegend/>,
         userPlaceGroup: userPlaceGroupSelector(state),

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -1,3 +1,4 @@
+import { TileSourceOptions } from './tile';
 import { Variable } from './variable';
 import { PlaceGroup } from './place';
 import { TimeRange } from './timeSeries';
@@ -28,6 +29,14 @@ export interface TimeDimension extends Dimension {
     labels: string[];
 }
 
+export type NormRange = [number, number];
+
+export interface RgbSchema {
+    tileSourceOptions: TileSourceOptions;
+    varNames: [string, string, string];
+    normRanges: [NormRange, NormRange, NormRange];
+}
+
 export interface Dataset {
     id: string;
     title: string;
@@ -37,6 +46,7 @@ export interface Dataset {
     placeGroups?: PlaceGroup[];
     attributions?: string[];
     attrs: { [name: string]: any };
+    rgbSchema?: RgbSchema;
 }
 
 

--- a/src/model/tile.ts
+++ b/src/model/tile.ts
@@ -1,0 +1,14 @@
+export interface TileGrid {
+    extent: [number, number, number, number];
+    origin: [number, number];
+    tileSize: [number, number];
+    resolutions: number[];
+}
+
+export interface TileSourceOptions {
+    url: string;
+    projection: string;
+    minZoom: number;
+    maxZoom: number;
+    tileGrid: TileGrid;
+}

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -1,3 +1,5 @@
+import { TileSourceOptions } from './tile';
+
 export interface Variable {
     id: string;
     name: string;
@@ -6,7 +8,7 @@ export interface Variable {
     dtype: string;
     units: string;
     title: string;
-    tileSourceOptions: any;
+    tileSourceOptions: TileSourceOptions;
     colorBarName: string;
     colorBarMin: number;
     colorBarMax: number;

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -5,7 +5,8 @@ import {
     ADD_ACTIVITY,
     CHANGE_LOCALE,
     CLOSE_DIALOG,
-    ControlAction, FLY_TO,
+    ControlAction,
+    FLY_TO,
     INC_SELECTED_TIME,
     OPEN_DIALOG,
     REMOVE_ACTIVITY,
@@ -17,6 +18,7 @@ import {
     SELECT_TIME_SERIES_UPDATE_MODE,
     SELECT_VARIABLE,
     SET_MAP_INTERACTION,
+    SET_RGB_LAYER_VISIBILITY,
     SET_VISIBLE_INFO_CARD_ELEMENTS,
     SHOW_INFO_CARD,
     UPDATE_INFO_CARD_ELEMENT_VIEW_MODE,
@@ -161,6 +163,12 @@ export function controlReducer(state: ControlState | undefined, action: ControlA
             return {
                 ...state,
                 selectedVariableName: action.selectedVariableName,
+            };
+        }
+        case SET_RGB_LAYER_VISIBILITY: {
+            return {
+                ...state,
+                showRgbLayer: action.showRgbLayer,
             };
         }
         case SELECT_TIME: {

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -524,6 +524,13 @@
       "it": "non verificato",
       "ro": "nu e verificat",
       "se": "inte verifierad"
+    },
+    {
+      "en": "RGB",
+      "de": "RGB",
+      "it": "RGB",
+      "ro": "RGB",
+      "se": "RGB"
     }
   ]
 }

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -47,6 +47,7 @@ export interface ControlState {
     infoCardElementStates: InfoCardElementStates;
     imageSmoothingEnabled: boolean;
     baseMapUrl: string;
+    showRgbLayer: boolean;
 }
 
 
@@ -73,6 +74,7 @@ export function newControlState(): ControlState {
         dialogOpen: {},
         legalAgreementAccepted: false,
         mapInteraction: 'Point',
+        showRgbLayer: false,
         infoCardOpen: false,
         infoCardElementStates: {
             dataset: {visible: true, viewMode: 'text'},


### PR DESCRIPTION
* Please first review https://github.com/dcs4cop/xcube/pull/279!
* Added a "RGB" switch to the app bar that is used to display the selected dataset's RGB layer, 
  if any. Currently, RGB layers can only be configured through the xcube server. Later xcube viewer 
  versions will allow users selecting three variables and their respective value ranges for normalisation.