### PR TITLE
can now switch between median and mean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Enhancements
 
+* Users can now switch between median and mean methods for the spatial aggregation of 
+  polygons when creating time-series. The setting is available in the settings dialog. 
+  (partly addresses #135). 
 * Added a "RGB" switch to the app bar that is used to display the selected dataset's RGB layer, 
   if any. Currently, RGB layers can only be configured through the xcube server. Later xcube viewer 
   versions will allow users selecting three variables and their respective value ranges for normalisation.

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -183,6 +183,7 @@ export function addTimeSeries() {
         const selectedPlaceId = selectedPlaceIdSelector(getState());
         const selectedPlace = selectedPlaceSelector(getState())!;
         const timeSeriesUpdateMode = getState().controlState.timeSeriesUpdateMode;
+        const useMedian = getState().controlState.showTimeSeriesMedian;
         const inclStDev = getState().controlState.showTimeSeriesErrorBars;
         let timeChunkSize = getState().controlState.timeChunkSize;
 
@@ -207,6 +208,7 @@ export function addTimeSeries() {
                                                     selectedPlace.geometry,
                                                     startDateLabel,
                                                     endDateLabel,
+                                                    useMedian,
                                                     inclStDev,
                                                     getState().userAuthState.accessToken);
             };

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -234,6 +234,14 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                                 updateSettings={updateSettings}
                             />
                         </SettingsSubPanel>
+                        <SettingsSubPanel label={I18N.get('Show median instead of mean (disables error bars)')}
+                                          value={getOnOff(settings.showTimeSeriesMedian)}>
+                            <ToggleSetting
+                                propertyName={'showTimeSeriesMedian'}
+                                settings={settings}
+                                updateSettings={updateSettings}
+                            />
+                        </SettingsSubPanel>
                         <SettingsSubPanel label={I18N.get('Number of data points in a time series update')}>
                             <TextField
                                 className={classes.intTextField}

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ interface Branding {
     logoPath: any;
     logoWidth: number;
     baseMapUrl?: string;
+    defaultAgg?: 'median' | 'mean';
 }
 
 const brandings: { [name: string]: Branding } = {
@@ -53,6 +54,7 @@ const brandings: { [name: string]: Branding } = {
         logoPath: require('./resources/default/logo.png'),
         logoWidth: 32,
         baseMapUrl: 'http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        defaultAgg: 'mean',
     },
     'esdl': {
         appBarTitle: 'ESDL Viewer',
@@ -67,6 +69,7 @@ const brandings: { [name: string]: Branding } = {
         logoPath: require('./resources/esdl/logo.png'),
         logoWidth: 64,
         baseMapUrl: 'http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        defaultAgg: 'mean',
     },
     'eodatabee': {
         appBarTitle: 'Demo Viewer',
@@ -86,6 +89,7 @@ const brandings: { [name: string]: Branding } = {
         logoPath: require('./resources/eodatabee/logo.png'),
         logoWidth: 150,
         baseMapUrl: 'http://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+        defaultAgg: 'mean',
     },
     'cyanoalert': {
         appBarTitle: '',
@@ -105,6 +109,7 @@ const brandings: { [name: string]: Branding } = {
         logoPath: require('./resources/cyanoalert/logo.png'),
         logoWidth: 120,
         baseMapUrl: 'https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
+        defaultAgg: 'median',
     },
 };
 

--- a/src/model/timeSeries.ts
+++ b/src/model/timeSeries.ts
@@ -1,4 +1,3 @@
-
 /**
  * Time is an integer value that is the number of milliseconds since 1 January 1970 UTC (Unix Time Stamp).
  */
@@ -20,14 +19,20 @@ export interface TimeSeriesSource {
     variableName: string;
     variableUnits?: string;
     placeId: string;
+    valueDataKey: keyof TimeSeriesPoint;
+    errorDataKey: keyof TimeSeriesPoint | null;
 }
 
 export interface TimeSeriesPoint {
     time: Time;
-    totalCount: number;
-    validCount: number;
-    average: number | null;
-    uncertainty?: number | null;
+    countTot: number;
+    count?: number;
+    mean?: number | null;
+    median?: number | null;
+    std?: number | null;
+    min?: number | null;
+    max?: number | null;
+    standard_error?: number | null;
 }
 
 export interface TimeSeries {

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -316,6 +316,13 @@
       "se": "Visa felstaplar"
     },
     {
+      "en": "Show median instead of mean (disables error bars)",
+      "de": "Median statt Mittelwert anzeigen (deaktiviert Fehlerbalken)",
+      "it": "Mostra la mediana invece della media (disabilita le barre di errore)",
+      "ro": "Arată mediana în loc de medie (dezactivează barele de eroare)",
+      "se": "Visa median i stället för medelvärde (inaktiverar felfält)"
+    },
+    {
       "en": "Number of data points in a time series update",
       "de": "Anzahl Datenpunkte in einer Zeitreihen-Aktualisierung",
       "it": "Numero di punti dati in un aggiornamento di serie storiche",

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -38,6 +38,7 @@ export interface ControlState {
     autoShowTimeSeries: boolean;
     showTimeSeriesPointsOnly: boolean;
     showTimeSeriesErrorBars: boolean;
+    showTimeSeriesMedian: boolean;
     flyTo: OlGeometry | OlExtent | null;
     activities: { [id: string]: string };
     locale: string;
@@ -70,6 +71,7 @@ export function newControlState(): ControlState {
         autoShowTimeSeries: true,
         showTimeSeriesPointsOnly: false,
         showTimeSeriesErrorBars: true,
+        showTimeSeriesMedian: branding.defaultAgg === 'median',
         flyTo: null,
         activities: {},
         locale: 'en',

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -35,6 +35,7 @@ export function storeUserSettings(settings: ControlState) {
             storage.setPrimitiveProperty('autoShowTimeSeries', settings);
             storage.setPrimitiveProperty('showTimeSeriesErrorBars', settings);
             storage.setPrimitiveProperty('showTimeSeriesPointsOnly', settings);
+            storage.setPrimitiveProperty('showTimeSeriesMedian', settings);
             storage.setPrimitiveProperty('timeAnimationInterval', settings);
             storage.setPrimitiveProperty('timeChunkSize', settings);
             storage.setPrimitiveProperty('imageSmoothingEnabled', settings);
@@ -56,6 +57,7 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
             storage.getBooleanProperty('autoShowTimeSeries', settings, defaultSettings);
             storage.getBooleanProperty('showTimeSeriesErrorBars', settings, defaultSettings);
             storage.getBooleanProperty('showTimeSeriesPointsOnly', settings, defaultSettings);
+            storage.getBooleanProperty('showTimeSeriesMedian', settings, defaultSettings);
             storage.getIntProperty('timeAnimationInterval', settings, defaultSettings);
             storage.getIntProperty('timeChunkSize', settings, defaultSettings);
             storage.getBooleanProperty('imageSmoothingEnabled', settings, defaultSettings);


### PR DESCRIPTION
Users can now switch between median and mean methods for the spatial aggregation of 
polygons when creating time-series. The setting is available in the settings dialog. 
(partly addresses #135).

* Testing the new function requires xcube branch https://github.com/dcs4cop/xcube/tree/forman-292-ts_agg_methods.
* Please first see PR https://github.com/dcs4cop/xcube/pull/293
