### PR TITLE
xcube viewer to support nested datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Changes in version 0.5.0 (in development)
 
+### Enhancements
+
 * Users can now manually enter a variable's min/max values that are
   applied to the selected color bar. The editor that pops up 
   when clicking the value range scale in the variable legend overlay.
@@ -37,6 +39,13 @@
   The JSON schema for the configuration is given in
   `src/resources/config.schema.json`.
   
+### Fixes
+
+* Fixed issue with datasets originating from nested, filesystem-based
+  data stores such as the "s3" and "file" data stores. See also 
+  related https://github.com/dcs4cop/xcube/issues/579.  
+  (#190)
+
 * Fixed eslint warnings of type "'ACTION' is already defined" during build.
 
 ## Changes in version 0.4.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcube-viewer",
-  "version": "0.5.0-dev.1",
+  "version": "0.5.0-dev.2",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/src/api/getDatasetPlaceGroup.ts
+++ b/src/api/getDatasetPlaceGroup.ts
@@ -22,11 +22,21 @@
  * SOFTWARE.
  */
 
-import { callJsonApi, makeRequestInit } from './callApi';
-import { PlaceGroup } from '../model/place';
+import {callJsonApi, makeRequestInit} from './callApi';
+import {PlaceGroup} from '../model/place';
 
 
-export function getDatasetPlaceGroup(apiServerUrl: string, dsId: string, placeGroupId: string, accessToken: string | null): Promise<PlaceGroup> {
+export function getDatasetPlaceGroup(
+    apiServerUrl: string,
+    datasetId: string,
+    placeGroupId: string,
+    accessToken: string | null
+): Promise<PlaceGroup> {
     const init = makeRequestInit(accessToken);
-    return callJsonApi<PlaceGroup>(`${apiServerUrl}/datasets/${dsId}/places/${placeGroupId}`, init);
+    const dsId = encodeURIComponent(datasetId);
+    const pgId = encodeURIComponent(placeGroupId);
+    return callJsonApi<PlaceGroup>(
+        `${apiServerUrl}/datasets/${dsId}/places/${pgId}`,
+        init
+    );
 }

--- a/src/api/getTimeSeries.ts
+++ b/src/api/getTimeSeries.ts
@@ -60,7 +60,12 @@ export function getTimeSeriesForGeometry(apiServerUrl: string,
     if (endDate) {
         query.push(['endDate', endDate]);
     }
-    const url = makeRequestUrl(`${apiServerUrl}/timeseries/${datasetId}/${variable.name}`, query);
+    const dsId = encodeURIComponent(datasetId);
+    const variableName = encodeURIComponent(variable.name);
+    const url = makeRequestUrl(
+        `${apiServerUrl}/timeseries/${dsId}/${variableName}`,
+        query
+    );
 
     const init = {
         ...makeRequestInit(accessToken),

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-const version = '0.5.0-dev.1';
+const version = '0.5.0-dev.2';
 
 export default version;
 


### PR DESCRIPTION
Fixed issue with datasets originating from nested, filesystem-based data stores such as the "s3" and "file" data stores. See also related https://github.com/dcs4cop/xcube/issues/588.  

Closes #190