### PR TITLE
logo in the application's main bar is now a link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changes in version 0.5.0 (in development)
 
+* The logo in the application's main bar is now a link.
+  The target URL can be configured using the 
+  `branding.organisationUrl` key. (#190)
+
 * Users can now manually enter a variable's min/max values that are
   applied to the selected color bar. The editor that pops up 
   when clicking the value range scale in the variable legend overlay.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 * The logo in the application's main bar is now a link.
   The target URL can be configured using the 
-  `branding.organisationUrl` key. (#190)
+  `branding.organisationUrl` key. (#176)
 
 * Users can now manually enter a variable's min/max values that are
   applied to the selected color bar. The editor that pops up 

--- a/src/connected/AppBar.tsx
+++ b/src/connected/AppBar.tsx
@@ -40,14 +40,14 @@ import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SettingsIcon from '@material-ui/icons/Settings';
 import classNames from 'classnames';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { openDialog } from '../actions/controlActions';
+import {connect} from 'react-redux';
+import {openDialog} from '../actions/controlActions';
 import MarkdownPage from '../components/MarkdownPage';
-import { Config } from '../config';
+import {Config} from '../config';
 import i18n from '../i18n';
 
-import { AppState } from '../states/appState';
-import { WithLocale } from '../util/lang';
+import {AppState} from '../states/appState';
+import {WithLocale} from '../util/lang';
 import ExportDialog from './ExportDialog';
 import ServerDialog from './ServerDialog';
 import SettingsDialog from './SettingsDialog';
@@ -165,13 +165,24 @@ const _AppBar: React.FC<AppBarProps> = ({classes, appName, openDialog}: AppBarPr
             className={classNames(classes.appBar)}
         >
             <Toolbar disableGutters className={classes.toolbar} variant="dense">
-                <img
-                    src={Config.instance.branding.logoImage}
-                    width={Config.instance.branding.logoWidth}
-                    alt={'xcube resources'}
-                    className={classes.logo}
-                />
-                <Typography component="h1" variant="h6" color="inherit" noWrap className={classes.title}>
+                <a
+                    href={Config.instance.branding.organisationUrl || ""}
+                    target="_blank"
+                >
+                    <img
+                        src={Config.instance.branding.logoImage}
+                        width={Config.instance.branding.logoWidth}
+                        alt={'xcube resources'}
+                        className={classes.logo}
+                    />
+                </a>
+                <Typography
+                    component="h1"
+                    variant="h6"
+                    color="inherit"
+                    noWrap
+                    className={classes.title}
+                >
                     {appName}
                 </Typography>
                 <UserControl/>

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -11,9 +11,10 @@
     "themeName": "dark",
     "primaryColor": "blue",
     "secondaryColor": "pink",
+    "organisationUrl": "https://xcube.readthedocs.io/",
     "logoImage": "images/logo.png",
     "logoWidth": 32,
-    "baseMapUrl": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    "baseMapUrl": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
     "defaultAgg": "mean",
     "allowDownloads": true,
     "polygonFillOpacity": 0.2

--- a/src/resources/config.schema.json
+++ b/src/resources/config.schema.json
@@ -77,7 +77,7 @@
         "baseMapUrl": {
           "type": "string",
           "format": "uri-template",
-          "example": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+          "example": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
         },
         "defaultAgg": {
           "type": "string",

--- a/src/resources/maps.json
+++ b/src/resources/maps.json
@@ -25,7 +25,7 @@
   },
   {
     "name": "ESRI",
-    "link": "http://services.arcgisonline.com/arcgis/rest/services",
+    "link": "https://services.arcgisonline.com/arcgis/rest/services",
     "datasets": [
       {
         "name": "Dark Gray Base",

--- a/src/util/branding.ts
+++ b/src/util/branding.ts
@@ -43,8 +43,8 @@ import {
     teal,
     yellow,
 } from '@material-ui/core/colors';
-import { Color } from '@material-ui/core';
-import { PaletteColorOptions } from '@material-ui/core/styles/createPalette';
+import {Color} from '@material-ui/core';
+import {PaletteColorOptions} from '@material-ui/core/styles/createPalette';
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -78,6 +78,7 @@ export interface Branding {
     primaryColor: PaletteColorOptions;
     secondaryColor: PaletteColorOptions;
     headerBackgroundColor?: string;
+    organisationUrl?: string;
     logoImage: any;
     logoWidth: number;
     baseMapUrl?: string;
@@ -103,7 +104,7 @@ function setBrandingImage(brandingConfig: any, key: keyof Branding, configPath: 
     const imagePath = brandingConfig[key];
     if (typeof imagePath === 'string') {
         const imageUrl = window.location.origin + '/'
-                         + (configPath !== '' ? `${configPath}/${imagePath}` : imagePath);
+            + (configPath !== '' ? `${configPath}/${imagePath}` : imagePath);
         brandingConfig[key] = imageUrl;
     }
 }


### PR DESCRIPTION
* The logo in the application's main bar is now a link. The target URL can be configured using the `branding.organisationUrl` key. 

Closes #176