### PR TITLE
Fixed rendering places, allow for map projection configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 ## Changes in version 0.10.1 (in development)
 
+### Enhancements
+
+* The map projection can now be configured using the
+  `branding.mapProjection` key. Possible values are the default
+  `"EPSG:4326"` (Geographic) and 
+  `"EPSG:3857"` (Spherical Mercator).
+
 ### Fixes
+
+* Feature geometries loaded from xcube Places API are now rendered again
+  in the map.
 
 * Addressed warning saying `Using target="_blank" without rel="noreferrer" 
   is a security risk`

--- a/src/components/ol/Map.tsx
+++ b/src/components/ol/Map.tsx
@@ -52,6 +52,7 @@ interface MapProps extends OlMapOptions {
     onClick?: (event: OlMapBrowserEvent) => void;
     onMapRef?: (map: OlMap | null) => void;
     isStale?: boolean;
+    projection?: string;
 }
 
 interface MapState {
@@ -85,6 +86,7 @@ export class Map extends React.Component<MapProps, MapState> {
         const mapOptions = {...this.props};
         delete mapOptions['children'];
         delete mapOptions['onClick'];
+        delete mapOptions['projection'];
         return mapOptions;
     }
 
@@ -126,7 +128,7 @@ export class Map extends React.Component<MapProps, MapState> {
     componentDidMount(): void {
         // console.log('Map.componentDidMount: id =', this.props.id);
 
-        const {id} = this.props;
+        const {id, projection} = this.props;
         const mapDiv = this.contextValue.mapDiv!;
 
         let map: OlMap | null = null;
@@ -144,7 +146,7 @@ export class Map extends React.Component<MapProps, MapState> {
         if (!map) {
             const initialZoom = this.getMinZoom(mapDiv);
             const view = new OlView({
-                                        projection: 'EPSG:4326',
+                                        projection: projection || 'EPSG:4326',
                                         center: olProjFromLonLat([0, 0]),
                                         minZoom: initialZoom,
                                         zoom: initialZoom,

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -17,6 +17,7 @@
     "baseMapUrl": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
     "defaultAgg": "mean",
     "allowDownloads": true,
-    "polygonFillOpacity": 0.2
+    "polygonFillOpacity": 0.2,
+    "mapProjection": "EPSG:4326"
   }
 }

--- a/src/resources/config.schema.json
+++ b/src/resources/config.schema.json
@@ -90,6 +90,9 @@
           "minimum": 0.0,
           "maximum": 1.0,
           "example": 0.025
+        },
+        "mapProjection": {
+          "enum": ["EPSG:4326", "EPSG:3857"]
         }
       },
       "additionalProperties": false

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -22,24 +22,23 @@
  * SOFTWARE.
  */
 
-import { default as OlGeoJSONFormat } from 'ol/format/GeoJSON';
-import { get as olProjGet } from 'ol/proj'
-import { default as OlVectorSource } from 'ol/source/Vector';
-import { default as OlXYZSource } from 'ol/source/XYZ';
-import { default as OlCircle } from 'ol/style/Circle';
-///<reference path="../util/find.ts"/>
-import { default as OlFillStyle } from 'ol/style/Fill';
-import { default as OlStrokeStyle } from 'ol/style/Stroke';
-import { default as OlStyle } from 'ol/style/Style';
-import { default as OlTileGrid } from 'ol/tilegrid/TileGrid';
+import {default as OlGeoJSONFormat} from 'ol/format/GeoJSON';
+import {get as olProjGet} from 'ol/proj'
+import {default as OlVectorSource} from 'ol/source/Vector';
+import {default as OlXYZSource} from 'ol/source/XYZ';
+import {default as OlCircle} from 'ol/style/Circle';
+import {default as OlFillStyle} from 'ol/style/Fill';
+import {default as OlStrokeStyle} from 'ol/style/Stroke';
+import {default as OlStyle} from 'ol/style/Style';
+import {default as OlTileGrid} from 'ol/tilegrid/TileGrid';
 import * as React from 'react';
-import { createSelector } from 'reselect'
-import { Layers } from '../components/ol/layer/Layers';
-import { Tile } from '../components/ol/layer/Tile';
-import { Vector } from '../components/ol/layer/Vector';
-import { MapElement } from '../components/ol/Map';
-import { Config, getTileAccess } from '../config';
-import { ApiServerConfig } from '../model/apiServer';
+import {createSelector} from 'reselect'
+import {Layers} from '../components/ol/layer/Layers';
+import {Tile} from '../components/ol/layer/Tile';
+import {Vector} from '../components/ol/layer/Vector';
+import {MapElement} from '../components/ol/Map';
+import {Config, getTileAccess} from '../config';
+import {ApiServerConfig} from '../model/apiServer';
 import {
     Dataset,
     findDataset,
@@ -58,19 +57,14 @@ import {
     PlaceGroup,
     PlaceInfo,
 } from '../model/place';
-import { TileSourceOptions } from '../model/tile';
-import { Time, TimeRange, TimeSeriesGroup } from '../model/timeSeries';
-import { Variable } from '../model/variable';
+import {TileSourceOptions} from '../model/tile';
+import {Time, TimeRange, TimeSeriesGroup} from '../model/timeSeries';
+import {Variable} from '../model/variable';
 
-import { AppState } from '../states/appState';
-import { findIndexCloseTo } from '../util/find';
-import { MapGroup, maps, MapSource } from '../util/maps';
-import {
-    datasetsSelector,
-    timeSeriesGroupsSelector,
-    userPlaceGroupSelector,
-    userServersSelector
-} from './dataSelectors';
+import {AppState} from '../states/appState';
+import {findIndexCloseTo} from '../util/find';
+import {MapGroup, maps, MapSource} from '../util/maps';
+import {datasetsSelector, timeSeriesGroupsSelector, userPlaceGroupSelector, userServersSelector} from './dataSelectors';
 
 export const selectedDatasetIdSelector = (state: AppState) => state.controlState.selectedDatasetId;
 export const selectedVariableNameSelector = (state: AppState) => state.controlState.selectedVariableName;
@@ -84,6 +78,8 @@ export const imageSmoothingSelector = (state: AppState) => state.controlState.im
 export const baseMapUrlSelector = (state: AppState) => state.controlState.baseMapUrl;
 export const showRgbLayerSelector = (state: AppState) => state.controlState.showRgbLayer;
 export const infoCardElementStatesSelector = (state: AppState) => state.controlState.infoCardElementStates;
+// noinspection JSUnusedLocalSymbols
+export const mapProjectionSelector = (state: AppState) => Config.instance.branding.mapProjection || 'EPSG:4326';
 
 export const selectedDatasetSelector = createSelector(
     datasetsSelector,
@@ -420,13 +416,13 @@ export const selectedDatasetRgbLayerSelector = createSelector(
             return null;
         }
         return getTileLayer('rgb',
-                            rgbSchema.tileSourceOptions,
-                            '',
-                            timeDimension,
-                            time,
-                            timeAnimationActive,
-                            attributions,
-                            imageSmoothing);
+            rgbSchema.tileSourceOptions,
+            '',
+            timeDimension,
+            time,
+            timeAnimationActive,
+            attributions,
+            imageSmoothing);
     }
 );
 
@@ -437,36 +433,45 @@ export function getDefaultFillOpacity() {
 
 export function getDefaultStyleImage() {
     return new OlCircle({
-                            fill: getDefaultFillStyle(),
-                            stroke: getDefaultStrokeStyle(),
-                            radius: 6
-                        })
+        fill: getDefaultFillStyle(),
+        stroke: getDefaultStrokeStyle(),
+        radius: 6
+    })
 }
 
 export function getDefaultStrokeStyle() {
     return new OlStrokeStyle({
-                                 color: [200, 0, 0, 0.75],
-                                 width: 1.25
-                             });
+        color: [200, 0, 0, 0.75],
+        width: 1.25
+    });
 }
 
 export function getDefaultFillStyle() {
     return new OlFillStyle({
-                               color: [255, 0, 0, getDefaultFillOpacity()]
-                           });
+        color: [255, 0, 0, getDefaultFillOpacity()]
+    });
 }
 
 export function getDefaultPlaceGroupStyle() {
     return new OlStyle({
-                           image: getDefaultStyleImage(),
-                           stroke: getDefaultStrokeStyle(),
-                           fill: getDefaultFillStyle(),
-                       });
+        image: getDefaultStyleImage(),
+        stroke: getDefaultStrokeStyle(),
+        fill: getDefaultFillStyle(),
+    });
 }
+
+export const selectedMapProjection = createSelector(
+    selectedDatasetSelector,
+    (dataset: Dataset | null): TimeRange | null => {
+        return dataset !== null ? getDatasetTimeRange(dataset) : null;
+    }
+);
+
 
 export const selectedDatasetPlaceGroupLayersSelector = createSelector(
     selectedDatasetSelectedPlaceGroupsSelector,
-    (placeGroups: PlaceGroup[]): MapElement => {
+    mapProjectionSelector,
+    (placeGroups: PlaceGroup[], mapProjection: string): MapElement => {
         if (placeGroups.length === 0) {
             return null;
         }
@@ -481,10 +486,12 @@ export const selectedDatasetPlaceGroupLayersSelector = createSelector(
                         zIndex={100}
                         source={new OlVectorSource(
                             {
-                                features: new OlGeoJSONFormat({
-                                                                  dataProjection: 'EPSG:4326',
-                                                                  featureProjection: 'EPSG:3857'
-                                                              }).readFeatures(placeGroup),
+                                features: new OlGeoJSONFormat(
+                                    {
+                                        dataProjection: 'EPSG:4326',
+                                        featureProjection: mapProjection
+                                    }
+                                ).readFeatures(placeGroup),
                             })}
                     />);
             }

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -460,14 +460,6 @@ export function getDefaultPlaceGroupStyle() {
     });
 }
 
-export const selectedMapProjection = createSelector(
-    selectedDatasetSelector,
-    (dataset: Dataset | null): TimeRange | null => {
-        return dataset !== null ? getDatasetTimeRange(dataset) : null;
-    }
-);
-
-
 export const selectedDatasetPlaceGroupLayersSelector = createSelector(
     selectedDatasetSelectedPlaceGroupsSelector,
     mapProjectionSelector,

--- a/src/util/branding.ts
+++ b/src/util/branding.ts
@@ -85,6 +85,7 @@ export interface Branding {
     defaultAgg?: 'median' | 'mean';
     polygonFillOpacity?: number;
     allowDownloads?: boolean;
+    mapProjection?: string;
 }
 
 


### PR DESCRIPTION
In this PR:

* Feature geometries loaded from xcube Places API are now rendered again in the map.
* The map projection can now be configured using the `branding.mapProjection` key. Possible values are the default `"EPSG:4326"` (Geographic) and `"EPSG:3857"` (Spherical Mercator).

