### PR TITLE
Added opacity slider (to CRS branch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Changes in version 0.10.2 (in development)
 
+### Enhancements
+
+* Now the opacity of tile layers can be changed from the color bar
+  dropdown component in the map.
+
 ### Fixes
 
 * Fixed a problem that occurred with datasets referring to the 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "classnames": "^2.2.6",
     "color-rgba": "^2.2.3",
     "date-fns": "^2.9.0",
+    "fast-memoize": "^2.5.2",
     "file-saver": "^2.0.5",
     "history": "^4.10.1",
     "jszip": "^3.7.0",

--- a/src/actions/controlActions.tsx
+++ b/src/actions/controlActions.tsx
@@ -163,8 +163,8 @@ export function selectPlaceGroups(selectedPlaceGroupIds: string[] | null) {
                 if (!isValidPlaceGroup(placeGroup)) {
                     const datasetId = dataset!.id;
                     const placeGroupId = placeGroup.id;
-                    const activitityId = `${UPDATE_DATASET_PLACE_GROUP}-${datasetId}-${placeGroupId}`;
-                    dispatch(addActivity(activitityId, i18n.get('Loading places')));
+                    const activityId = `${UPDATE_DATASET_PLACE_GROUP}-${datasetId}-${placeGroupId}`;
+                    dispatch(addActivity(activityId, i18n.get('Loading places')));
                     api.getDatasetPlaceGroup(apiServer.url,
                                              datasetId,
                                              placeGroupId,
@@ -176,7 +176,7 @@ export function selectPlaceGroups(selectedPlaceGroupIds: string[] | null) {
                            dispatch(postMessage('error', error));
                        })
                        .finally(() => {
-                           dispatch(removeActivity(activitityId));
+                           dispatch(removeActivity(activityId));
                        });
                 }
             }

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -375,14 +375,20 @@ export interface UpdateVariableColorBar {
     variableName: string;
     colorBarMinMax: [number, number];
     colorBarName: string;
+    opacity: number;
 }
 
-export function updateVariableColorBar(colorBarMinMax: [number, number], colorBarName: string) {
+export function updateVariableColorBar(colorBarMinMax: [number, number],
+                                       colorBarName: string,
+                                       opacity: number) {
     return (dispatch: Dispatch<UpdateVariableColorBar>, getState: () => AppState) => {
         const selectedDatasetId = getState().controlState.selectedDatasetId;
         const selectedVariableName = getState().controlState.selectedVariableName;
         if (selectedDatasetId && selectedVariableName) {
-            dispatch(_updateVariableColorBar(selectedDatasetId, selectedVariableName, colorBarMinMax, colorBarName));
+            dispatch(_updateVariableColorBar(
+                selectedDatasetId, selectedVariableName,
+                colorBarMinMax, colorBarName, opacity
+            ));
         }
     };
 }
@@ -390,8 +396,16 @@ export function updateVariableColorBar(colorBarMinMax: [number, number], colorBa
 export function _updateVariableColorBar(datasetId: string,
                                         variableName: string,
                                         colorBarMinMax: [number, number],
-                                        colorBarName: string): UpdateVariableColorBar {
-    return {type: UPDATE_VARIABLE_COLOR_BAR, datasetId, variableName, colorBarMinMax, colorBarName};
+                                        colorBarName: string,
+                                        opacity: number): UpdateVariableColorBar {
+    return {
+        type: UPDATE_VARIABLE_COLOR_BAR,
+        datasetId,
+        variableName,
+        colorBarMinMax,
+        colorBarName,
+        opacity
+    };
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/components/ColorBarLegend.tsx
+++ b/src/components/ColorBarLegend.tsx
@@ -111,7 +111,8 @@ interface ColorBarLegendProps {
     variableUnits: string;
     variableColorBarMinMax: [number, number];
     variableColorBarName: string;
-    updateVariableColorBar: (colorBarMinMax: [number, number], colorBarName: string) => void;
+    variableOpacity: number;
+    updateVariableColorBar: (colorBarMinMax: [number, number], colorBarName: string, opacity: number) => void;
     colorBars: ColorBars | null;
     width?: number | string;
     height?: number | string;
@@ -123,6 +124,7 @@ export default function ColorBarLegend({
                                            variableUnits,
                                            variableColorBarMinMax,
                                            variableColorBarName,
+                                           variableOpacity,
                                            updateVariableColorBar,
                                            colorBars,
                                            width, height,
@@ -177,7 +179,7 @@ export default function ColorBarLegend({
 
     const handleColorBarMinMaxChangeCommitted = (event: React.ChangeEvent<{}>, value: number | number[]) => {
         if (Array.isArray(value)) {
-            updateVariableColorBar([value[0], value[1]], variableColorBarName);
+            updateVariableColorBar([value[0], value[1]], variableColorBarName, variableOpacity);
         }
     };
 
@@ -193,16 +195,32 @@ export default function ColorBarLegend({
         if (variableColorBarAlpha) {
             variableColorBarName += ALPHA_SUFFIX;
         }
-        updateVariableColorBar(variableColorBarMinMax, variableColorBarName);
+        updateVariableColorBar(variableColorBarMinMax, variableColorBarName, variableOpacity);
     };
 
     const handleColorBarAlpha = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.currentTarget.checked) {
-            updateVariableColorBar(variableColorBarMinMax, variableColorBarBaseName + ALPHA_SUFFIX);
+            updateVariableColorBar(
+                variableColorBarMinMax,
+                variableColorBarBaseName + ALPHA_SUFFIX,
+                variableOpacity
+            );
         } else {
-            updateVariableColorBar(variableColorBarMinMax, variableColorBarBaseName);
+            updateVariableColorBar(
+                variableColorBarMinMax,
+                variableColorBarBaseName,
+                variableOpacity
+            );
         }
     };
+
+    const handleVariableOpacity = (event: React.ChangeEvent<{}>, value: number | number[]) => {
+        updateVariableColorBar(
+            variableColorBarMinMax,
+            variableColorBarName,
+            value as number
+        );
+    }
 
     const handleEnteredColorBarMinChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const enteredValue = event.target.value;
@@ -214,7 +232,7 @@ export default function ColorBarLegend({
                 const newMinMax: [number, number] = [minValue, currentColorBarMinMax[1]];
                 setCurrentColorBarMinMax(newMinMax);
                 setOriginalColorBarMinMax(newMinMax);
-                updateVariableColorBar(newMinMax, variableColorBarName);
+                updateVariableColorBar(newMinMax, variableColorBarName, variableOpacity);
             }
         } else {
             error = true;
@@ -232,7 +250,7 @@ export default function ColorBarLegend({
                 const newMinMax: [number, number] = [currentColorBarMinMax[0], maxValue]
                 setCurrentColorBarMinMax(newMinMax);
                 setOriginalColorBarMinMax(newMinMax);
-                updateVariableColorBar(newMinMax, variableColorBarName);
+                updateVariableColorBar(newMinMax, variableColorBarName, variableOpacity);
             }
         } else {
             error = true;
@@ -371,8 +389,21 @@ export default function ColorBarLegend({
                 <Box component="span">
                     <Checkbox color="primary"
                               checked={variableColorBarAlpha}
-                              onChange={handleColorBarAlpha}/>
+                              onChange={handleColorBarAlpha}
+                              size="small"
+                              style={{paddingLeft: 0, paddingTop: 4, paddingBottom: 4}}/>
                     <Box component="span">{i18n.get('Hide lower values')}</Box>
+                </Box>
+                <Box component="div" style={{display: 'flex', alignItems: 'center'}}>
+                    <span>{i18n.get('Opacity')}</span>
+                    <Slider
+                        min={0}
+                        max={1}
+                        value={variableOpacity}
+                        step={0.01}
+                        style={{flexGrow: 1, marginLeft: 10, marginRight: 10}}
+                        onChange={handleVariableOpacity}
+                    />
                 </Box>
                 {entries}
             </Box>

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -257,8 +257,6 @@ const Viewer: React.FC<ViewerProps> = ({
                 onMapRef={setMap}
                 mapObjects={MAP_OBJECTS}
                 isStale={true}
-                // projection={mapProjection}
-                // maxTilesLoading={8}
             >
                 <View id="view" projection={mapProjection}/>
                 <Layers>

--- a/src/components/ol/Map.tsx
+++ b/src/components/ol/Map.tsx
@@ -23,14 +23,13 @@
  */
 
 import * as React from 'react';
-import { default as OlMap } from 'ol/Map';
-import { default as OlBaseObject } from 'ol/Object';
-import { default as OlMapBrowserEvent } from 'ol/MapBrowserEvent';
-import { default as OlView } from 'ol/View';
-import { default as OlEvent } from 'ol/events/Event';
-import { EventsKey as OlEventsKey } from 'ol/events';
-import { MapOptions as OlMapOptions } from 'ol/PluggableMap';
-import { fromLonLat as olProjFromLonLat } from 'ol/proj';
+import {default as OlMap} from 'ol/Map';
+import {default as OlBaseObject} from 'ol/Object';
+import {default as OlMapBrowserEvent} from 'ol/MapBrowserEvent';
+import {default as OlView} from 'ol/View';
+import {default as OlEvent} from 'ol/events/Event';
+import {EventsKey as OlEventsKey} from 'ol/events';
+import {MapOptions as OlMapOptions} from 'ol/PluggableMap';
 
 import 'ol/ol.css';
 import './Map.css';
@@ -53,13 +52,12 @@ interface MapProps extends OlMapOptions {
     onClick?: (event: OlMapBrowserEvent) => void;
     onMapRef?: (map: OlMap | null) => void;
     isStale?: boolean;
-    projection?: string;
 }
 
 interface MapState {
 }
 
-const DEFAULT_CONTAINER_SYTLE: React.CSSProperties = {height: '100%'};
+const DEFAULT_CONTAINER_STYLE: React.CSSProperties = {height: '100%'};
 
 export class Map extends React.Component<MapProps, MapState> {
 
@@ -83,53 +81,10 @@ export class Map extends React.Component<MapProps, MapState> {
         }
     }
 
-    private getMapOptions(): OlMapOptions {
-        const mapOptions = {...this.props};
-        delete mapOptions['children'];
-        delete mapOptions['onClick'];
-        delete mapOptions['projection'];
-        return mapOptions;
-    }
-
-    private handleClick = (event: OlEvent) => {
-        const onClick = this.props.onClick;
-        if (onClick) {
-            onClick(event as OlMapBrowserEvent);
-        }
-    };
-
-    private handleRef = (mapDiv: HTMLDivElement | null) => {
-        this.contextValue.mapDiv = mapDiv;
-    };
-
-    private handleResize = () => {
-        const mapDiv = this.contextValue.mapDiv;
-        const map = this.contextValue.map;
-        if (mapDiv && map) {
-            map.updateSize();
-            const view = map.getView();
-            const minZoom = this.getMinZoom(mapDiv);
-            if (minZoom !== view.getMinZoom()) {
-                view.setMinZoom(minZoom);
-            }
-        }
-    };
-
-    private getMinZoom = (target: HTMLDivElement) => {
-        // Adjust the view's minZoom so there is only one world,
-        // see https://openlayers.org/en/latest/examples/min-zoom.html
-        const size = target.clientWidth;
-        const minZoom = Math.LOG2E * Math.log(size / 256);
-        if (minZoom >= 0.0) {
-            return minZoom;
-        }
-        return 0;
-    };
-
     componentDidMount(): void {
         // console.log('Map.componentDidMount: id =', this.props.id);
 
-        const {id, projection} = this.props;
+        const {id} = this.props;
         const mapDiv = this.contextValue.mapDiv!;
 
         let map: OlMap | null = null;
@@ -147,17 +102,16 @@ export class Map extends React.Component<MapProps, MapState> {
         if (!map) {
             const initialZoom = this.getMinZoom(mapDiv);
             const view = new OlView({
-                                        projection: projection || DEFAULT_MAP_CRS,
-                                        center: olProjFromLonLat([0, 0]),
-                                        minZoom: initialZoom,
-                                        zoom: initialZoom,
-                                    });
+                projection: DEFAULT_MAP_CRS,
+                center: [0, 0],
+                minZoom: initialZoom,
+                zoom: initialZoom,
+            });
             map = new OlMap({
-                                view,
-                                ...this.getMapOptions(),
-                                target: mapDiv
-                            });
-
+                view,
+                ...this.getMapOptions(),
+                target: mapDiv
+            });
         }
 
         this.contextValue.map = map;
@@ -231,10 +185,52 @@ export class Map extends React.Component<MapProps, MapState> {
             );
         }
         return (
-            <div ref={this.handleRef} style={DEFAULT_CONTAINER_SYTLE}>
+            <div ref={this.handleRef} style={DEFAULT_CONTAINER_STYLE}>
                 {childrenWithContext}
             </div>
         );
     }
+
+    private getMapOptions(): OlMapOptions {
+        const mapOptions = {...this.props};
+        delete mapOptions['children'];
+        delete mapOptions['onClick'];
+        return mapOptions;
+    }
+
+    private handleClick = (event: OlEvent) => {
+        const onClick = this.props.onClick;
+        if (onClick) {
+            onClick(event as OlMapBrowserEvent);
+        }
+    };
+
+    private handleRef = (mapDiv: HTMLDivElement | null) => {
+        this.contextValue.mapDiv = mapDiv;
+    };
+
+    private handleResize = () => {
+        const mapDiv = this.contextValue.mapDiv;
+        const map = this.contextValue.map;
+        if (mapDiv && map) {
+            map.updateSize();
+            const view = map.getView();
+            const minZoom = this.getMinZoom(mapDiv);
+            if (minZoom !== view.getMinZoom()) {
+                view.setMinZoom(minZoom);
+            }
+        }
+    };
+
+    private getMinZoom = (target: HTMLDivElement) => {
+        // Adjust the view's minZoom so there is only one world,
+        // see https://openlayers.org/en/latest/examples/min-zoom.html
+        const size = target.clientWidth;
+        const minZoom = Math.LOG2E * Math.log(size / 256);
+        if (minZoom >= 0.0) {
+            return minZoom;
+        }
+        return 0;
+    };
 }
 

--- a/src/components/ol/View.tsx
+++ b/src/components/ol/View.tsx
@@ -35,14 +35,17 @@ interface ViewProps extends MapComponentProps, OlViewOptions {
 export class View extends MapComponent<OlView, ViewProps> {
 
     addMapObject(map: OlMap): OlView {
-        map.getView().setProperties(this.props);
-        return map.getView();
+        return this.updateView(map);
     }
 
     removeMapObject(map: OlMap, object: OlView): void {
     }
 
     updateMapObject(map: OlMap, object: OlView): OlView {
+        return this.updateView(map);
+    }
+
+    updateView(map: OlMap): OlView {
         const newProjection = this.props.projection;
         let oldProjection: OlProjectionLike = map.getView().getProjection();
         if (typeof newProjection === 'string') {

--- a/src/components/ol/layer/Tile.tsx
+++ b/src/components/ol/layer/Tile.tsx
@@ -34,8 +34,10 @@ import { Options as OlTileLayerOptions } from 'ol/layer/BaseTile';
 
 import { MapComponent, MapComponentProps } from '../MapComponent';
 
+const DEBUG = false;
+
 let trace: (message?: string, ...optionalParams: any[]) => void;
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && DEBUG) {
     trace = console.debug;
 } else {
     trace = () => {};

--- a/src/components/ol/layer/Tile.tsx
+++ b/src/components/ol/layer/Tile.tsx
@@ -34,6 +34,12 @@ import { Options as OlTileLayerOptions } from 'ol/layer/BaseTile';
 
 import { MapComponent, MapComponentProps } from '../MapComponent';
 
+let trace: (message?: string, ...optionalParams: any[]) => void;
+if (process.env.NODE_ENV === 'development') {
+    trace = console.debug;
+} else {
+    trace = () => {};
+}
 
 // noinspection JSUnusedGlobalSymbols
 export function NaturalEarth2(): JSX.Element {
@@ -95,7 +101,7 @@ export class Tile extends MapComponent<OlTileLayer, TileProps> {
                 const oldTileGrid = oldUrlTileSource.getTileGrid();
                 const newTileGrid = newUrlTileSource.getTileGrid();
                 if (equalTileGrids(oldTileGrid, newTileGrid)) {
-                    // console.debug("--> Equal tile grids!")
+                    trace("--> Equal tile grids!")
                     const oldUrls = oldUrlTileSource.getUrls();
                     const newUrls = newUrlTileSource.getUrls();
                     if (oldUrls !== newUrls && newUrls && (oldUrls === null || oldUrls[0] !== newUrls[0])) {
@@ -115,7 +121,7 @@ export class Tile extends MapComponent<OlTileLayer, TileProps> {
                         replaceSource = false;
                     }
                 } else {
-                    // console.debug('--> Tile grids are not equal!');
+                    trace('--> Tile grids are not equal!');
                 }
             }
             const oldContextOptions = oldSource.getContextOptions()
@@ -131,11 +137,12 @@ export class Tile extends MapComponent<OlTileLayer, TileProps> {
             if (replaceSource) {
                 // Replace the entire source and accept layer flickering.
                 layer.setSource(newSource);
-                // console.debug("--> Replaced source")
+                trace("--> Replaced source (expect flickering!)")
             } else {
-                // console.debug("--> Updated source (?)")
+                trace("--> Updated source (check, is it still flickering?)")
             }
         }
+
         // TODO: Code duplication in ./Vector.tsx
         if (this.props.visible && this.props.visible !== prevProps.visible) {
             layer.setVisible(this.props.visible);
@@ -191,9 +198,10 @@ const OSM_BW_SOURCE = new OlXYZSource(
 
 
 function equalTileGrids(oldTileGrid: OlTileGrid, newTileGrid: OlTileGrid) {
+    trace('tile grid:', oldTileGrid, newTileGrid);
     // Check min/max zoom level
-    // console.debug('min zoom:', oldTileGrid.getMinZoom(), newTileGrid.getMinZoom());
-    // console.debug('max zoom:', oldTileGrid.getMaxZoom(), newTileGrid.getMaxZoom());
+    trace('min zoom:', oldTileGrid.getMinZoom(), newTileGrid.getMinZoom());
+    trace('max zoom:', oldTileGrid.getMaxZoom(), newTileGrid.getMaxZoom());
     if (oldTileGrid.getMinZoom() !== newTileGrid.getMinZoom()
         || oldTileGrid.getMaxZoom() !== newTileGrid.getMaxZoom()) {
         return false;
@@ -202,7 +210,7 @@ function equalTileGrids(oldTileGrid: OlTileGrid, newTileGrid: OlTileGrid) {
     // Check extents
     const oldExtent = oldTileGrid.getExtent();
     const newExtent = newTileGrid.getExtent();
-    // console.debug('extent:', oldExtent, newExtent);
+    trace('extent:', oldExtent, newExtent);
     for (let i = 0; i < oldExtent.length; i++) {
         if (oldExtent[i] !== newExtent[i]) {
             return false;
@@ -212,7 +220,7 @@ function equalTileGrids(oldTileGrid: OlTileGrid, newTileGrid: OlTileGrid) {
     // Check number of z-levels
     const oldResolutions = oldTileGrid.getResolutions();
     const newResolutions = newTileGrid.getResolutions();
-    // console.debug('resolutions:', oldResolutions, newResolutions);
+    trace('resolutions:', oldResolutions, newResolutions);
     const numLevels = oldResolutions.length;
     if (numLevels !== newResolutions.length) {
         return false;
@@ -223,14 +231,14 @@ function equalTileGrids(oldTileGrid: OlTileGrid, newTileGrid: OlTileGrid) {
         // Check resolution
         const oldResolution = oldTileGrid.getResolution(z);
         const newResolution = newTileGrid.getResolution(z);
-        // console.debug(`resolution ${z}:`, oldResolution, newResolution);
+        trace(`resolution ${z}:`, oldResolution, newResolution);
         if (oldResolution !== newResolution) {
             return false;
         }
         // Check origin
         const oldOrigin = oldTileGrid.getOrigin(z);
         const newOrigin = newTileGrid.getOrigin(z);
-        // console.debug(`origin ${z}:`, oldOrigin, newOrigin);
+        trace(`origin ${z}:`, oldOrigin, newOrigin);
         for (let i = 0; i < oldOrigin.length; i++) {
             if (oldOrigin[i] !== newOrigin[i]) {
                 return false;
@@ -239,7 +247,7 @@ function equalTileGrids(oldTileGrid: OlTileGrid, newTileGrid: OlTileGrid) {
         // Check tile size
         let oldTileSize = oldTileGrid.getTileSize(z);
         let newTileSize = newTileGrid.getTileSize(z);
-        // console.debug(`tile size ${z}:`, oldTileSize, newTileSize);
+        trace(`tile size ${z}:`, oldTileSize, newTileSize);
         for (let i = 0; i < oldOrigin.length; i++) {
             if (typeof oldTileSize === 'number') {
                 oldTileSize = [oldTileSize, oldTileSize]
@@ -255,9 +263,13 @@ function equalTileGrids(oldTileGrid: OlTileGrid, newTileGrid: OlTileGrid) {
         // Check tile range
         let oldTileRange = oldTileGrid.getFullTileRange(z);
         let newTileRange = newTileGrid.getFullTileRange(z);
-        // console.debug(`tile range ${z}:`, oldTileRange, newTileRange);
-        if (oldTileRange.getWidth() !== newTileRange.getWidth()
-            || oldTileRange.getHeight() !== newTileRange.getHeight()) {
+        trace(`tile range ${z}:`, oldTileRange, newTileRange);
+        if (oldTileRange && newTileRange) {
+            if (oldTileRange.getWidth() !== newTileRange.getWidth()
+                || oldTileRange.getHeight() !== newTileRange.getHeight()) {
+                return false;
+            }
+        } else if (!!oldTileRange || !!newTileRange) {
             return false;
         }
     }

--- a/src/connected/ColorBarLegend.tsx
+++ b/src/connected/ColorBarLegend.tsx
@@ -29,7 +29,7 @@ import {
     selectedVariableNameSelector,
     selectedVariableUnitsSelector,
     selectedVariableColorBarNameSelector,
-    selectedVariableColorBarMinMaxSelector,
+    selectedVariableColorBarMinMaxSelector, selectedVariableOpacitySelector,
 } from '../selectors/controlSelectors';
 import { updateVariableColorBar } from '../actions/dataActions';
 import ColorBarLegend from '../components/ColorBarLegend';
@@ -41,6 +41,7 @@ const mapStateToProps = (state: AppState) => {
         variableUnits: selectedVariableUnitsSelector(state),
         variableColorBarMinMax: selectedVariableColorBarMinMaxSelector(state),
         variableColorBarName: selectedVariableColorBarNameSelector(state),
+        variableOpacity: selectedVariableOpacitySelector(state),
         colorBars: state.dataState.colorBars,
     }
 };

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -56,8 +56,10 @@ export interface TimeDimension extends Dimension {
 export type NormRange = [number, number];
 
 export interface RgbSchema {
-    // tileUrl is new since xcube 0.11
+    // The following are new since xcube 0.11
     tileUrl: string;
+    tileLevelMin?: number;
+    tileLevelMax?: number;
     // tileSourceOptions are longer used since xcube 0.11
     tileSourceOptions?: TileSourceOptions;
     varNames: [string, string, string];

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -36,6 +36,7 @@ export interface Variable {
     colorBarName: string;
     colorBarMin: number;
     colorBarMax: number;
+    opacity?: number;
     htmlRepr?: string;
     attrs: { [name: string]: any };
 }

--- a/src/reducers/dataReducer.ts
+++ b/src/reducers/dataReducer.ts
@@ -66,7 +66,8 @@ export function dataReducer(state: DataState | undefined, action: DataAction): D
                         ...variable,
                         colorBarMin: action.colorBarMinMax[0],
                         colorBarMax: action.colorBarMinMax[1],
-                        colorBarName: action.colorBarName
+                        colorBarName: action.colorBarName,
+                        opacity: action.opacity,
                     };
                     datasets[datasetIndex] = {...dataset, variables};
                     return {...state, datasets};

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -400,6 +400,13 @@
       "se": "Dölj lägre värden"
     },
     {
+      "en": "Opacity",
+      "de": "Opazität",
+      "it": "Opacità",
+      "ro": "Opacitate",
+      "se": "Opacitet"
+    },
+    {
       "en": "Dataset information",
       "de": "Informationen zum Datensatz",
       "it": "Informazioni sul set di dati",

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -126,6 +126,16 @@ export const selectedVariableColorBarNameSelector = createSelector(
     }
 );
 
+export const selectedVariableOpacitySelector = createSelector(
+    selectedVariableSelector,
+    (variable: Variable | null): number => {
+        if (!variable || typeof variable.opacity != 'number') {
+            return 1;
+        }
+        return variable.opacity;
+    }
+);
+
 export const selectedDatasetTimeRangeSelector = createSelector(
     selectedDatasetSelector,
     (dataset: Dataset | null): TimeRange | null => {
@@ -318,6 +328,7 @@ export const selectedTimeIndexSelector = createSelector(
 function getTileLayer(layerId: string,
                       tileSourceOptions: TileSourceOptions,
                       queryParams: string,
+                      opacity: number,
                       timeDimension: TimeDimension | null,
                       time: number | null,
                       timeAnimationActive: boolean,
@@ -354,7 +365,7 @@ function getTileLayer(layerId: string,
             imageSmoothing: imageSmoothing,
         });
     return (
-        <Tile id={layerId} source={source} zIndex={10}/>
+        <Tile id={layerId} source={source} zIndex={10} opacity={opacity}/>
     );
 }
 
@@ -365,6 +376,7 @@ export const selectedDatasetVariableLayerSelector = createSelector(
     timeAnimationActiveSelector,
     selectedVariableColorBarMinMaxSelector,
     selectedVariableColorBarNameSelector,
+    selectedVariableOpacitySelector,
     selectedDatasetAttributionsSelector,
     imageSmoothingSelector,
     (variable: Variable | null,
@@ -373,6 +385,7 @@ export const selectedDatasetVariableLayerSelector = createSelector(
      timeAnimationActive: boolean,
      colorBarMinMax: [number, number],
      colorBarName: string,
+     opacity: number,
      attributions: string[] | null,
      imageSmoothing: boolean
     ): MapElement => {
@@ -387,6 +400,7 @@ export const selectedDatasetVariableLayerSelector = createSelector(
             'variable',
             variable.tileSourceOptions,
             `vmin=${colorBarMinMax[0]}&vmax=${colorBarMinMax[1]}&cbar=${colorBarName}`,
+            opacity,
             timeDimension,
             time,
             timeAnimationActive,
@@ -399,6 +413,7 @@ export const selectedDatasetVariableLayerSelector = createSelector(
 export const selectedDatasetRgbLayerSelector = createSelector(
     showRgbLayerSelector,
     selectedDatasetRgbSchemaSelector,
+    selectedVariableOpacitySelector,
     selectedDatasetTimeDimensionSelector,
     selectedTimeSelector,
     timeAnimationActiveSelector,
@@ -406,6 +421,7 @@ export const selectedDatasetRgbLayerSelector = createSelector(
     imageSmoothingSelector,
     (showRgbLayer: boolean,
      rgbSchema: RgbSchema | null,
+     opacity: number,
      timeDimension: TimeDimension | null,
      time: Time | null,
      timeAnimationActive: boolean,
@@ -418,6 +434,7 @@ export const selectedDatasetRgbLayerSelector = createSelector(
         return getTileLayer('rgb',
             rgbSchema.tileSourceOptions,
             '',
+            opacity,
             timeDimension,
             time,
             timeAnimationActive,

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -357,7 +357,7 @@ function getOlXYZSource(url: string,
                         imageSmoothing: boolean,
                         tileLoadFunction: any,
                         tileLevelMin: number | undefined,
-                        tileLevelMax: undefined | number) {
+                        tileLevelMax: number | undefined) {
     return new OlXYZSource(
         {
             url,
@@ -367,7 +367,10 @@ function getOlXYZSource(url: string,
             transition: timeAnimationActive ? 0 : 250,
             imageSmoothing: imageSmoothing,
             tileLoadFunction,
-            minZoom: tileLevelMin,
+            // TODO (forman): if we provide minZoom, we also need to set
+            //   tileGrid.extent, otherwise way to many tiles are loaded from
+            //   level at minZoom when zooming out!
+            // minZoom: tileLevelMin,
             maxZoom: tileLevelMax,
         });
 }

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -555,8 +555,8 @@ export const selectedDatasetRgbLayerSelector = createSelector(
         ];
         return getTileLayer('rgb',
             rgbSchema.tileUrl,
-            undefined,
-            undefined,
+            rgbSchema.tileLevelMin,
+            rgbSchema.tileLevelMax,
             queryParams,
             opacity,
             timeDimension,

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -104,10 +104,15 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
             storage.getBooleanProperty('exportPlacesAsCollection', settings, defaultSettings);
             storage.getBooleanProperty('exportZipArchive', settings, defaultSettings);
             storage.getStringProperty('exportFileName', settings, defaultSettings);
+            if (process.env.NODE_ENV === 'development') {
+                console.debug('Loaded user settings:', settings);
+            }
         } catch (e) {
-            console.warn(`failed to load user settings: ${e}`);
+            console.warn(`Failed to load user settings: ${e}`);
         }
         return settings;
+    } else {
+        console.warn('User settings not found or access denied');
     }
     return defaultSettings;
 }

--- a/src/states/userSettings.ts
+++ b/src/states/userSettings.ts
@@ -66,6 +66,7 @@ export function storeUserSettings(settings: ControlState) {
             storage.setPrimitiveProperty('infoCardOpen', settings);
             storage.setObjectProperty('infoCardElementStates', settings);
             storage.setPrimitiveProperty('imageSmoothingEnabled', settings);
+            storage.setPrimitiveProperty('mapProjection', settings);
             storage.setPrimitiveProperty('baseMapUrl', settings);
             storage.setPrimitiveProperty('exportTimeSeries', settings);
             storage.setPrimitiveProperty('exportTimeSeriesSeparator', settings);
@@ -95,6 +96,7 @@ export function loadUserSettings(defaultSettings: ControlState): ControlState {
             storage.getBooleanProperty('infoCardOpen', settings, defaultSettings);
             storage.getObjectProperty('infoCardElementStates', settings, defaultSettings);
             storage.getBooleanProperty('imageSmoothingEnabled', settings, defaultSettings);
+            storage.getStringProperty('mapProjection', settings, defaultSettings);
             storage.getStringProperty('baseMapUrl', settings, defaultSettings);
             storage.getBooleanProperty('exportTimeSeries', settings, defaultSettings);
             storage.getStringProperty('exportTimeSeriesSeparator', settings, defaultSettings);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5503,6 +5503,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-memoize@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
 fast-text-encoding@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"


### PR DESCRIPTION
Now the opacity of tile layers can be changed from the color bar dropdown component in the map.

![image](https://user-images.githubusercontent.com/206773/162188174-3e30d8a5-bff5-4e11-bead-314663394df6.png)

**NOTE**

This PR also fixes two bugs present in the branch [forman-xxx-crs_indepenence](https://github.com/dcs4cop/xcube-viewer/tree/forman-xxx-crs_indepenence):

* fixed flickering (once more)
* fixed bug for undefined "oldTileRange" 

