### PR TITLE
Use dataset time chunks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## Changes in version 0.11.1 (in development)
+
+### Enhancements
+
+* The performance of time-series fetching has been significantly improved
+  by exploiting the actual chunk sizes of the time dimension of a variable.
+  For this to work, the setting "Number of data points in a time series update" 
+  has been replaced by "_Minimal_ number of data points in a time series update".
+  The effective number of data points is now always an integer multiple of the
+  actual variable's time chunk size.
+
 ## Changes in version 0.11.0
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xcube-viewer",
-  "version": "0.11.0",
+  "version": "0.11.1-dev.0",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -39,7 +39,8 @@ import {
     selectedPlaceGroupsSelector,
     selectedPlaceIdSelector,
     selectedPlaceSelector,
-    selectedServerSelector
+    selectedServerSelector,
+    selectedTimeChunkSizeSelector
 } from '../selectors/controlSelectors';
 import { datasetsSelector, placeGroupsSelector, userPlaceGroupSelector } from '../selectors/dataSelectors';
 
@@ -208,7 +209,7 @@ export function addTimeSeries() {
         const timeSeriesUpdateMode = getState().controlState.timeSeriesUpdateMode;
         const useMedian = getState().controlState.showTimeSeriesMedian;
         const inclStDev = getState().controlState.showTimeSeriesErrorBars;
-        let timeChunkSize = getState().controlState.timeChunkSize;
+        let timeChunkSize = selectedTimeChunkSizeSelector(getState());
 
         const placeGroups = placeGroupsSelector(getState());
 

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -280,11 +280,14 @@ const VariableInfoContent: React.FC<VariableInfoContentProps> = ({isIn, viewMode
     let content;
     let htmlReprPaper;
     if (viewMode === 'code') {
-        const jsonVariable = selectObj(variable, ['id', 'name', 'title', 'units', 'shape', 'dtype',
-                                                  'colorBarMin',
-                                                  'colorBarMax',
-                                                  'colorBarName',
-                                                  'attrs']);
+        const jsonVariable = selectObj(variable, [
+            'id', 'name', 'title', 'units', 'shape', 'dtype', 'shape',
+            'timeChunkSize',
+            'colorBarMin',
+            'colorBarMax',
+            'colorBarName',
+            'attrs'
+        ]);
         content = (
             <CardContent2>
                 <Typography className={classes.code}>{JSON.stringify(jsonVariable, null, 2)}</Typography>
@@ -318,6 +321,7 @@ const VariableInfoContent: React.FC<VariableInfoContentProps> = ({isIn, viewMode
             [i18n.get('Data type'), variable.dtype],
             [i18n.get('Dimension names'), variable.dims.join(', ')],
             [i18n.get('Dimension lengths'), variable.shape.map(s => s + '').join(', ')],
+            [i18n.get('Time chunk size'), variable.timeChunkSize],
         ];
         content = (
             <CardContent2>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -251,7 +251,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                                 updateSettings={updateSettings}
                             />
                         </SettingsSubPanel>
-                        <SettingsSubPanel label={i18n.get('Number of data points in a time series update')}>
+                        <SettingsSubPanel label={i18n.get('Minimal number of data points in a time series update')}>
                             <TextField
                                 className={classes.intTextField}
                                 value={timeChunkSize}

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -23,6 +23,7 @@
  */
 
 import { TileSourceOptions } from './tile';
+import i18n from "../i18n";
 
 export interface Variable {
     id: string;
@@ -32,6 +33,7 @@ export interface Variable {
     dtype: string;
     units: string;
     title: string;
+    timeChunkSize: number | null;
     // tileUrl is new since xcube 0.11
     tileUrl?: string;
     tileLevelMin?: number;

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -323,11 +323,11 @@
       "se": "Visa median i stället för medelvärde (inaktiverar felfält)"
     },
     {
-      "en": "Number of data points in a time series update",
-      "de": "Anzahl Datenpunkte in einer Zeitreihen-Aktualisierung",
-      "it": "Numero di punti dati in un aggiornamento di serie storiche",
-      "ro": "Numărul de puncte de date dintr-o actualizare a seriei de timp",
-      "se": "Antal datapunkter i en tidsserieuppdatering"
+      "en": "Minimal number of data points in a time series update",
+      "de": "Minimale Anzahl Datenpunkte in einer Zeitreihen-Aktualisierung",
+      "it": "Numero minimo di punti dati in un aggiornamento delle serie temporali",
+      "ro": "Număr minim de puncte de date într -o actualizare a seriilor de timp",
+      "se": "Minimalt antal datapunkter i en tidsserieuppdatering"
     },
     {
       "en": "Legal Agreement",

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -83,6 +83,7 @@ export const baseMapUrlSelector = (state: AppState) => state.controlState.baseMa
 export const showRgbLayerSelector = (state: AppState) => state.controlState.showRgbLayer;
 export const infoCardElementStatesSelector = (state: AppState) => state.controlState.infoCardElementStates;
 export const mapProjectionSelector = (state: AppState) => state.controlState.mapProjection;
+export const timeChunkSizeSelector = (state: AppState) => state.controlState.timeChunkSize;
 
 export const selectedDatasetSelector = createSelector(
     datasetsSelector,
@@ -290,6 +291,18 @@ export const selectedDatasetVariableSelector = createSelector(
     selectedVariableNameSelector,
     (dataset: Dataset | null, variableName: string | null): Variable | null => {
         return (dataset && findDatasetVariable(dataset, variableName)) || null;
+    }
+);
+
+export const selectedTimeChunkSizeSelector = createSelector(
+    selectedDatasetVariableSelector,
+    timeChunkSizeSelector,
+    (variable: Variable | null, minTimeChunkSize): number => {
+        if (variable && variable.timeChunkSize) {
+            const varTimeChunkSize = variable.timeChunkSize;
+            return varTimeChunkSize * Math.ceil(minTimeChunkSize / varTimeChunkSize);
+        }
+        return minTimeChunkSize;
     }
 );
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-const version = '0.11.0';
+const version = '0.11.1-dev.0';
 
 export default version;
 


### PR DESCRIPTION
In this PR:

The performance of time-series fetching has been significantly improved by exploiting the actual chunk sizes of the time dimension of a variable.

For this to work, the setting "Number of data points in a time series update" has been replaced by "_Minimal_ number of data points in a time series update". The effective number of data points is now always an integer multiple of the actual variable's time chunk size.

**Important Note**: This PR requires https://github.com/dcs4cop/xcube/pull/675