### PR TITLE
Fix zooming into time-series chart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,14 @@
   The effective number of data points is now always an integer multiple of the
   actual variable's time chunk size.
 
+### Fixes
+
+* Fixed a bug that caused the app to crash when zooming into the 
+  time-series chart. (#163)
+
+* Text selection has now been disabled for the time-series charts.
+  Zooming in no longer selects the axes' labels.
+
 ## Changes in version 0.11.0
 
 ### Enhancements

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -62,7 +62,7 @@ const SUBSTITUTE_LABEL_COLOR = '#FAFFDD';
 const styles = (theme: Theme) => createStyles(
     {
         chartContainer: {
-            // userSelect: 'none',
+            userSelect: 'none',
             marginTop: theme.spacing(1),
             width: '99%',
             height: '32vh',
@@ -148,10 +148,24 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({
     const [firstTime, setFirstTime] = useState<number | null>(null);
     const [secondTime, setSecondTime] = useState<number | null>(null);
 
-    const setState = (isDragging: boolean, firstTime: number | null, secondTime: number | null) => {
+    const setState = (isDragging: boolean,
+                      firstTime: number | null | undefined,
+                      secondTime: number | null | undefined) => {
+        const firstTimeDefault = !isDragging && dataTimeRange && dataTimeRange[0];
+        const secondTimeDefault = !isDragging && dataTimeRange && dataTimeRange[1];
         setIsDragging(isDragging);
-        setFirstTime(firstTime);
-        setSecondTime(secondTime);
+        setFirstTime(typeof firstTime === 'number'
+            ? firstTime
+            : (typeof firstTimeDefault === 'number'
+                ? firstTimeDefault
+                : null)
+        );
+        setSecondTime(typeof secondTime === 'number'
+            ? secondTime
+            : (typeof secondTimeDefault === 'number'
+                ? secondTimeDefault
+                : null)
+        );
     };
 
     const clearState = () => {
@@ -192,18 +206,19 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({
     };
 
     const handleMouseDown = (event: any) => {
-        if (event) {
-            setState(false, event.activeLabel, null);
-        }
+        setState(false, event && event.activeLabel, null);
     };
 
     const handleMouseMove = (event: any) => {
-        if (event && firstTime) {
-            setState(true, firstTime, event.activeLabel);
+        if (firstTime !== null) {
+            setState(true, firstTime, event && event.activeLabel);
         }
     };
 
-    const handleMouseUp = () => {
+    const handleMouseUp = (event: any) => {
+        if (firstTime !== null) {
+            setState(false, firstTime, event && event.activeLabel);
+        }
         zoomIn();
     };
 

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -151,21 +151,14 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({
     const setState = (isDragging: boolean,
                       firstTime: number | null | undefined,
                       secondTime: number | null | undefined) => {
-        const firstTimeDefault = !isDragging && dataTimeRange && dataTimeRange[0];
-        const secondTimeDefault = !isDragging && dataTimeRange && dataTimeRange[1];
+        firstTime = toNumberOrNull(firstTime);
+        secondTime = toNumberOrNull(secondTime);
+        if (firstTime !== null && secondTime === null) {
+            secondTime = toNumberOrNull(dataTimeRange && dataTimeRange[1]);
+        }
         setIsDragging(isDragging);
-        setFirstTime(typeof firstTime === 'number'
-            ? firstTime
-            : (typeof firstTimeDefault === 'number'
-                ? firstTimeDefault
-                : null)
-        );
-        setSecondTime(typeof secondTime === 'number'
-            ? secondTime
-            : (typeof secondTimeDefault === 'number'
-                ? secondTimeDefault
-                : null)
-        );
+        setFirstTime(firstTime);
+        setSecondTime(secondTime);
     };
 
     const clearState = () => {
@@ -552,3 +545,7 @@ const CustomizedDot = (props: CustomizedDotProps) => {
 
     return null;
 };
+
+function toNumberOrNull(x: number | null | undefined): number | null {
+    return typeof x === 'number' ? x : null;
+}


### PR DESCRIPTION
In this PR:

* Fixed a bug that caused the app to crash when zooming into the time-series chart. 
* Text selection has now been disabled for the time-series charts. Zooming in no longer selects the axes' labels.

Closes #163