### PR TITLE
Improve header styling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,27 @@
   The effective number of data points is now always an integer multiple of the
   actual variable's time chunk size.
 
+* The style of the title and icons of the app's header bar can now be
+  customized by two new branding properties `` and `` that can provide
+  any CCS attributes (using camel-case attribute names). (#227)
+
+  For example
+  ```json
+  {   
+    "branding": {
+      "headerTitleStyle": {
+        "fontFamily": "courier",
+        "color": "yellow"
+      },
+      "headerIconStyle": {
+        "color": "black"
+      },
+      ...
+    },
+    ...
+  }
+  ```
+
 ## Changes in version 0.11.0
 
 ### Enhancements

--- a/src/connected/AppBar.tsx
+++ b/src/connected/AppBar.tsx
@@ -77,7 +77,7 @@ const styles = (theme: Theme) => createStyles(
     {
         toolbar: {
             backgroundColor: Config.instance.branding.headerBackgroundColor,
-            paddingRight: theme.spacing(1)
+            paddingRight: theme.spacing(1),
         },
         appBar: {
             zIndex: theme.zIndex.drawer + 1,
@@ -86,12 +86,17 @@ const styles = (theme: Theme) => createStyles(
                 duration: theme.transitions.duration.leavingScreen,
             }),
         },
+        logoAnchor: {
+            display: "flex",
+            alignItems: "center"
+        },
         logo: {
             marginLeft: theme.spacing(1),
         },
         title: {
             flexGrow: 1,
             marginLeft: theme.spacing(1),
+            ...Config.instance.branding.headerTitleStyle,
         },
         imageAvatar: {
             width: 24,
@@ -120,6 +125,7 @@ const styles = (theme: Theme) => createStyles(
         },
         iconButton: {
             marginLeft: theme.spacing(2),
+            ...Config.instance.branding.headerIconStyle,
         }
     }
 );
@@ -169,6 +175,7 @@ const _AppBar: React.FC<AppBarProps> = ({classes, appName, openDialog}: AppBarPr
                     href={Config.instance.branding.organisationUrl || ""}
                     target="_blank"
                     rel="noreferrer"
+                    className={classes.logoAnchor}
                 >
                     <img
                         src={Config.instance.branding.logoImage}

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -18,6 +18,6 @@
     "defaultAgg": "mean",
     "allowDownloads": true,
     "polygonFillOpacity": 0.2,
-    "mapProjection": "EPSG:4326",
+    "mapProjection": "EPSG:4326"
   }
 }

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -18,6 +18,6 @@
     "defaultAgg": "mean",
     "allowDownloads": true,
     "polygonFillOpacity": 0.2,
-    "mapProjection": "EPSG:4326"
+    "mapProjection": "EPSG:4326",
   }
 }

--- a/src/util/branding.ts
+++ b/src/util/branding.ts
@@ -45,6 +45,7 @@ import {
 } from '@material-ui/core/colors';
 import {Color} from '@material-ui/core';
 import {PaletteColorOptions} from '@material-ui/core/styles/createPalette';
+import { CSSProperties } from "react";
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -78,6 +79,8 @@ export interface Branding {
     primaryColor: PaletteColorOptions;
     secondaryColor: PaletteColorOptions;
     headerBackgroundColor?: string;
+    headerTitleStyle?: CSSProperties;
+    headerIconStyle?: CSSProperties;
     organisationUrl?: string;
     logoImage: any;
     logoWidth: number;


### PR DESCRIPTION
The style of the title and icons of the app's header bar can now be customized by two new branding properties `` and `` that can provide any CCS attributes (using camel-case attribute names). 

For example
```json
{   
  "branding": {
    "headerTitleStyle": {
      "fontFamily": "courier",
      "color": "yellow"
    },
    "headerIconStyle": {
      "color": "black"
    },
    ...
  },
  ...
}
```

- [x] centring of logo 
- [x] settings icons white appearance in light theme (or allow to define color for them in config)
- [x] allow to change font of    "windowTitle": "EDC xcube Viewer"
- [x] allow to change color of window tilte

Closes #227