### PR TITLE
Added query parameters `dataset` and `variable`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ### Enhancements
 
+* The viewer app can now be called with query parameters that
+  preselect the dataset and variable to be displayed.
+  The query parameters are `dataset` and `variable`. (#207) 
+
+  For example, when using the demo configuration, we can preselect
+  dataset with ID `remote` and the variable named `kd489`:
+
+      http://localhost:3000/?dataset=remote&variable=kd489
+
 * The performance of time-series fetching has been significantly improved
   by exploiting the actual chunk sizes of the time dimension of a variable.
   For this to work, the setting "Number of data points in a time series update" 

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -110,7 +110,7 @@ export function updateDatasets() {
            .then((datasets: Dataset[]) => {
                dispatch(_updateDatasets(datasets));
                if (datasets.length > 0) {
-                   const selectedDatasetId = datasets[0].id;
+                   const selectedDatasetId = getState().controlState.selectedDatasetId || datasets[0].id;
                    dispatch(selectDataset(selectedDatasetId, datasets, true) as any);
                }
            })

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,9 @@ import { AuthClientConfig } from './util/auth';
 import { Branding, parseBranding } from './util/branding';
 
 
+export const appParams = new URLSearchParams(window.location.search);
+
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class Config {
@@ -64,8 +67,7 @@ export class Config {
     }
 
     static async load(): Promise<Config> {
-        const urlParams = new URLSearchParams(window.location.search);
-        let configPath = urlParams.get('configPath') || 'config';
+        let configPath = appParams.get('configPath') || 'config';
         let rawConfig;
         try {
             const configUrl = window.location.origin + `/${configPath}/config.json`;
@@ -85,11 +87,11 @@ export class Config {
         const name = rawConfig.name || 'default';
         const authClient = rawConfig.authClient && {...rawConfig.authClient};
         const server = {...rawDefaultConfig.server, ...rawConfig.server} as ApiServerConfig;
-        server.id = urlParams.get('serverId') || server.id;
-        server.name = urlParams.get('serverName') || server.name;
-        server.url = urlParams.get('serverUrl') || server.url;
+        server.id = appParams.get('serverId') || server.id;
+        server.name = appParams.get('serverName') || server.name;
+        server.url = appParams.get('serverUrl') || server.url;
         const branding = parseBranding({...rawDefaultConfig.branding, ...rawConfig.branding},
-                                       configPath);
+            configPath);
         Config._instance = new Config(name, server, branding, authClient);
         if (process.env.NODE_ENV === 'development') {
             console.debug('Configuration:', Config._instance);

--- a/src/reducers/controlReducer.ts
+++ b/src/reducers/controlReducer.ts
@@ -64,8 +64,8 @@ import { AppState } from '../states/appState';
 import { ControlState, MAP_OBJECTS, newControlState } from '../states/controlState';
 import { storeUserSettings } from '../states/userSettings';
 import { findIndexCloseTo } from '../util/find';
-import {GEOGRAPHIC_CRS} from "../model/proj";
-
+import { GEOGRAPHIC_CRS } from "../model/proj";
+import { appParams } from "../config";
 
 // TODO (forman): Refactor reducers for UPDATE_DATASETS, SELECT_DATASET, SELECT_PLACE, SELECT_VARIABLE
 //                so they produce a consistent state. E.g. on selected dataset change, ensure selected
@@ -76,7 +76,9 @@ import {GEOGRAPHIC_CRS} from "../model/proj";
 //                  Consider providing a value that matches one of the available options or ''.
 //                  The available values are "".
 
-export function controlReducer(state: ControlState | undefined, action: ControlAction | DataAction, appState: AppState | undefined): ControlState {
+export function controlReducer(state: ControlState | undefined,
+                               action: ControlAction | DataAction,
+                               appState: AppState | undefined): ControlState {
     if (state === undefined) {
         state = newControlState();
     }
@@ -87,17 +89,15 @@ export function controlReducer(state: ControlState | undefined, action: ControlA
             return settings;
         }
         case UPDATE_DATASETS: {
-            let selectedDatasetId = state!.selectedDatasetId;
-            let selectedVariableName = state!.selectedVariableName;
+            let selectedDatasetId = state!.selectedDatasetId || appParams.get("dataset");
+            let selectedVariableName = state!.selectedVariableName || appParams.get("variable");
             let mapInteraction = state!.mapInteraction;
             let selectedDataset = findDataset(action.datasets, selectedDatasetId);
             const selectedVariable = (selectedDataset
-                                      && findDatasetVariable(selectedDataset, selectedVariableName))
-                                     || null;
+                    && findDatasetVariable(selectedDataset, selectedVariableName))
+                || null;
             if (selectedDataset) {
-                if (selectedVariable) {
-                    return state;
-                } else {
+                if (!selectedVariable) {
                     selectedVariableName = selectedDataset.variables.length ? selectedDataset.variables[0].name : null;
                 }
             } else {

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -29,7 +29,7 @@ import { Config } from '../config';
 
 import { Time, TimeRange } from '../model/timeSeries';
 import { loadUserSettings } from './userSettings';
-import {DEFAULT_MAP_CRS} from "../model/proj";
+import { DEFAULT_MAP_CRS } from "../model/proj";
 
 
 export type TimeAnimationInterval = 250 | 500 | 1000 | 2500;
@@ -94,8 +94,8 @@ export interface ControlState {
 export function newControlState(): ControlState {
     const branding = Config.instance.branding;
     const state: ControlState = {
-        selectedDatasetId: 'local',
-        selectedVariableName: 'conc_chl',
+        selectedDatasetId: null,
+        selectedVariableName: null,
         selectedPlaceGroupIds: ['user'],
         selectedPlaceId: null,
         selectedUserPlaceId: null,


### PR DESCRIPTION
The viewer app can now be called with query parameters that preselect the dataset and variable to be displayed. The query parameters are `dataset` and `variable`.

For example, when using the demo configuration, we can preselect dataset with ID `remote` and the variable named `kd489`:

      http://localhost:3000/?dataset=remote&variable=kd489

Closes #207