### PR TITLE
Show spatial reference system

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   The effective number of data points is now always an integer multiple of the
   actual variable's time chunk size.
 
+* In the info panel, the dataset's spatial reference system is shown. (#225)
+
 ### Fixes
 
 * Fixed a bug that caused the app to crash when zooming into the 

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -245,6 +245,7 @@ const DatasetInfoContent: React.FC<DatasetInfoContentProps> = ({isIn, viewMode, 
             [i18n.get('Dimension data types'), dataset.dimensions.map(d => d.dtype).join(', ')],
             [i18n.get('Dimension lengths'), dataset.dimensions.map(d => d.size).join(', ')],
             [i18n.get('Geographical extent') + ' (x1, y1, x2, y2)', dataset.bbox.map(x => x + '').join(', ')],
+            [i18n.get('Spatial reference system'), dataset.spatialRef],
         ];
         content = (
             <CardContent2>

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -70,6 +70,7 @@ export interface Dataset {
     id: string;
     title: string;
     bbox: [number, number, number, number];
+    spatialRef: string;
     dimensions: Dimension[];
     variables: Variable[];
     placeGroups?: PlaceGroup[];

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -484,6 +484,13 @@
       "se": "Geografisk omfattning"
     },
     {
+      "en": "Spatial reference system",
+      "de": "Räumliches Bezugssystem",
+      "it": "Sistema di riferimento spaziale",
+      "ro": "Sistem de referință spațială",
+      "se": "Rumsligt referenssystem"
+    },
+    {
       "en": "Name",
       "de": "Name",
       "it": "Nome",


### PR DESCRIPTION
In the info panel, the dataset's spatial reference system is shown.

**IMPORTANT:** requires https://github.com/dcs4cop/xcube/pull/684

Closes #225