### PR TITLE
Show spatial reference & dataset boundaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   The effective number of data points is now always an integer multiple of the
   actual variable's time chunk size.
 
+* In the info panel, the dataset's spatial reference system is shown. (#225)
+
 ### Fixes
 
 * Fixed a bug that caused the app to crash when zooming into the 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 
 * In the info panel, the dataset's spatial reference system is shown. (#225)
 
+* It is now possible to display dataset boundaries in the map.
+  A new setting "Show dataset boundaries" is available to switch this
+  feature on and off. (#226)
+
+
 ### Fixes
 
 * Fixed a bug that caused the app to crash when zooming into the 

--- a/src/components/InfoCard.tsx
+++ b/src/components/InfoCard.tsx
@@ -245,6 +245,7 @@ const DatasetInfoContent: React.FC<DatasetInfoContentProps> = ({isIn, viewMode, 
             [i18n.get('Dimension data types'), dataset.dimensions.map(d => d.dtype).join(', ')],
             [i18n.get('Dimension lengths'), dataset.dimensions.map(d => d.size).join(', ')],
             [i18n.get('Geographical extent') + ' (x1, y1, x2, y2)', dataset.bbox.map(x => x + '').join(', ')],
+            [i18n.get('Spatial reference system'), dataset.spatialRef],
         ];
         content = (
             <CardContent2>

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -287,6 +287,14 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                                 updateSettings={updateSettings}
                             />
                         </SettingsSubPanel>
+                        <SettingsSubPanel label={i18n.get('Show dataset boundaries')}
+                                          value={getOnOff(settings.showDatasetBoundaries)}>
+                            <ToggleSetting
+                                propertyName={'showDatasetBoundaries'}
+                                settings={settings}
+                                updateSettings={updateSettings}
+                            />
+                        </SettingsSubPanel>
                     </SettingsPanel>
 
                     <SettingsPanel title={i18n.get('System Information')}>

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -95,6 +95,7 @@ interface ViewerProps extends WithStyles<typeof styles> {
     baseMapLayer?: MapElement;
     rgbLayer?: MapElement;
     variableLayer?: MapElement;
+    datasetBoundaryLayer?: MapElement;
     placeGroupLayers?: MapElement;
     colorBarLegend?: MapElement;
     addUserPlace?: (id: string, label: string, color: string, geometry: geojson.Geometry) => void;
@@ -113,6 +114,7 @@ const Viewer: React.FC<ViewerProps> = ({
                                            baseMapLayer,
                                            rgbLayer,
                                            variableLayer,
+                                           datasetBoundaryLayer,
                                            placeGroupLayers,
                                            colorBarLegend,
                                            addUserPlace,
@@ -262,6 +264,7 @@ const Viewer: React.FC<ViewerProps> = ({
                 <Layers>
                     {baseMapLayer}
                     {variableLayer}
+                    {datasetBoundaryLayer}
                     <Vector
                         id='userLayer'
                         opacity={1}

--- a/src/connected/Viewer.tsx
+++ b/src/connected/Viewer.tsx
@@ -29,7 +29,7 @@ import {AppState} from '../states/appState';
 import {
     baseMapLayerSelector,
     imageSmoothingSelector,
-    mapProjectionSelector,
+    mapProjectionSelector, selectedDatasetBoundaryLayerSelector,
     selectedDatasetPlaceGroupLayersSelector,
     selectedDatasetRgbLayerSelector,
     selectedDatasetVariableLayerSelector,
@@ -47,6 +47,7 @@ const mapStateToProps = (state: AppState) => {
         locale: state.controlState.locale,
         variableLayer: selectedDatasetVariableLayerSelector(state),
         rgbLayer: selectedDatasetRgbLayerSelector(state),
+        datasetBoundaryLayer: selectedDatasetBoundaryLayerSelector(state),
         placeGroupLayers: selectedDatasetPlaceGroupLayersSelector(state),
         colorBarLegend: <ColorBarLegend/>,
         userPlaceGroup: userPlaceGroupSelector(state),

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -70,6 +70,7 @@ export interface Dataset {
     id: string;
     title: string;
     bbox: [number, number, number, number];
+    spatialRef: string;
     dimensions: Dimension[];
     variables: Variable[];
     placeGroups?: PlaceGroup[];

--- a/src/model/dataset.ts
+++ b/src/model/dataset.ts
@@ -70,6 +70,10 @@ export interface Dataset {
     id: string;
     title: string;
     bbox: [number, number, number, number];
+    geometry: {
+        type: "Polygon";
+        coordinates: Array<Array<[number, number]>>;
+    };
     spatialRef: string;
     dimensions: Dimension[];
     variables: Variable[];

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -407,6 +407,13 @@
       "se": "Bildutjämning"
     },
     {
+      "en": "Show dataset boundaries",
+      "de": "Datensatzgrenzen anzeigen",
+      "it": "Mostra i limiti del set di dati",
+      "ro": "Afișați limitele setului de date",
+      "se": "Visa datauppsättningsgränser"
+    },
+    {
       "en": "Base map",
       "de": "Basiskarte",
       "it": "Mappa di base",

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -484,6 +484,13 @@
       "se": "Geografisk omfattning"
     },
     {
+      "en": "Spatial reference system",
+      "de": "Räumliches Bezugssystem",
+      "it": "Sistema di riferimento spaziale",
+      "ro": "Sistem de referință spațială",
+      "se": "Rumsligt referenssystem"
+    },
+    {
       "en": "Name",
       "de": "Name",
       "it": "Nome",

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -538,8 +538,8 @@ export const selectedDatasetBoundaryLayerSelector = createSelector(
 
         const style = new OlStyle({
             stroke: new OlStrokeStyle({
-                color: "yellow",
-                width: 2,
+                color: "orange",
+                width: 3,
                 lineDash: [2, 4],
             }),
         });

--- a/src/states/controlState.ts
+++ b/src/states/controlState.ts
@@ -80,6 +80,7 @@ export interface ControlState {
     infoCardElementStates: InfoCardElementStates;
     mapProjection: string;
     imageSmoothingEnabled: boolean;
+    showDatasetBoundaries: boolean;
     baseMapUrl: string;
     showRgbLayer: boolean;
     exportTimeSeries: boolean;
@@ -125,6 +126,7 @@ export function newControlState(): ControlState {
         },
         mapProjection: branding.mapProjection || DEFAULT_MAP_CRS,
         imageSmoothingEnabled: false,
+        showDatasetBoundaries: false,
         baseMapUrl: branding.baseMapUrl || 'http://a.tile.osm.org/{z}/{x}/{y}.png',
         exportTimeSeries: true,
         exportTimeSeriesSeparator: 'TAB',


### PR DESCRIPTION
* In the info panel, the dataset's spatial reference system is shown.
* It is now possible to display dataset boundaries in the map. A new setting "Show dataset boundaries" is available to switch this feature on and off. 

**IMPORTANT:** Requires https://github.com/dcs4cop/xcube/pull/685

Closes #225
Closes #226
