### PR TITLE
Update server-side resources and refresh the page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Changes in version 0.11.2-dev.0 (in development) 
 
+### Enhancements
+
+* A new refresh icon in the main bar now allows updating 
+  server-side resources and refresh the page.
+  For this to work, the configuration setting 
+  `branding.allowRefresh` must be `true`.
+
 ## Changes in version 0.11.1
 
 ### Enhancements

--- a/src/actions/dataActions.tsx
+++ b/src/actions/dataActions.tsx
@@ -93,6 +93,27 @@ export function _updateServerInfo(serverInfo: ApiServerInfo): UpdateServerInfo {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+export const UPDATE_RESOURCES = 'UPDATE_RESOURCES';
+
+export function updateResources() {
+    return (dispatch: Dispatch<UpdateDatasets | SelectDataset | AddActivity | RemoveActivity | MessageLogAction>, getState: () => AppState) => {
+        const apiServer = selectedServerSelector(getState());
+        dispatch(addActivity(UPDATE_RESOURCES, i18n.get('Updating resources')));
+        api.updateResources(apiServer.url, getState().userAuthState.accessToken)
+            .then(ok => {
+                if (ok) {
+                    window.location.reload();
+                }
+            })
+            .finally(() =>
+                dispatch(removeActivity(UPDATE_DATASETS))
+            );
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 export const UPDATE_DATASETS = 'UPDATE_DATASETS';
 
 export interface UpdateDatasets {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,6 +25,7 @@
 export { getServerInfo } from './getServerInfo'
 export { getColorBars } from './getColorBars'
 export { getDatasets } from './getDatasets'
+export { updateResources } from './updateResources'
 export { getDatasetPlaceGroup } from './getDatasetPlaceGroup'
 export { getTimeSeriesForGeometry } from './getTimeSeries'
 export { HTTPError } from './errors'

--- a/src/api/updateResources.ts
+++ b/src/api/updateResources.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019-2021 by the xcube development team and contributors.
+ * Copyright (c) 2022 by the xcube development team and contributors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/src/api/updateResources.ts
+++ b/src/api/updateResources.ts
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2021 by the xcube development team and contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { callJsonApi, makeRequestInit, makeRequestUrl } from './callApi';
+
+
+export function updateResources(apiServerUrl: string, accessToken: string | null): Promise<boolean> {
+    const url = makeRequestUrl(`${apiServerUrl}/maintenance/update`, []);
+    const init = makeRequestInit(accessToken);
+    try {
+        return callJsonApi<boolean>(url, init)
+            .then(() => {
+                return true;
+            })
+            .catch(error => {
+                console.error(error);
+                return false;
+            });
+    } catch (error) {
+        console.error(error);
+        return Promise.resolve(false);
+    }
+}

--- a/src/connected/AppBar.tsx
+++ b/src/connected/AppBar.tsx
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+import * as React from 'react';
+import { connect } from 'react-redux';
 import {
     AppBar,
     createStyles,
@@ -38,25 +40,27 @@ import deepOrange from '@material-ui/core/colors/deepOrange';
 import Tooltip from '@material-ui/core/Tooltip';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SettingsIcon from '@material-ui/icons/Settings';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import classNames from 'classnames';
-import * as React from 'react';
-import {connect} from 'react-redux';
-import {openDialog} from '../actions/controlActions';
-import MarkdownPage from '../components/MarkdownPage';
-import {Config} from '../config';
-import i18n from '../i18n';
 
-import {AppState} from '../states/appState';
-import {WithLocale} from '../util/lang';
+import MarkdownPage from '../components/MarkdownPage';
+import { Config } from '../config';
+import i18n from '../i18n';
+import { AppState } from '../states/appState';
+import { WithLocale } from '../util/lang';
 import ExportDialog from './ExportDialog';
 import ServerDialog from './ServerDialog';
 import SettingsDialog from './SettingsDialog';
 import UserControl from './UserControl';
+import { openDialog } from '../actions/controlActions';
+import { updateResources } from "../actions/dataActions";
 
 
 interface AppBarProps extends WithStyles<typeof styles>, WithLocale {
     appName: string;
-    openDialog: (dialogId: string) => void;
+    openDialog: (dialogId: string) => any;
+    allowRefresh?: boolean;
+    updateResources: () => any;
 }
 
 
@@ -65,11 +69,13 @@ const mapStateToProps = (state: AppState) => {
     return {
         locale: state.controlState.locale,
         appName: Config.instance.branding.appBarTitle,
+        allowRefresh: Config.instance.branding.allowRefresh,
     };
 };
 
 const mapDispatchToProps = {
     openDialog,
+    updateResources,
 };
 
 
@@ -130,7 +136,14 @@ const styles = (theme: Theme) => createStyles(
     }
 );
 
-const _AppBar: React.FC<AppBarProps> = ({classes, appName, openDialog}: AppBarProps) => {
+const _AppBar: React.FC<AppBarProps> = (
+    {
+        classes,
+        appName,
+        openDialog,
+        allowRefresh,
+        updateResources
+    }: AppBarProps) => {
     const [helpMenuAnchorEl, setHelpMenuAnchorEl] = React.useState(null);
     const [imprintOpen, setImprintOpen] = React.useState(false);
     const [manualOpen, setManualOpen] = React.useState(false);
@@ -165,6 +178,10 @@ const _AppBar: React.FC<AppBarProps> = ({classes, appName, openDialog}: AppBarPr
         setImprintOpen(false);
     };
 
+    const handleRefresh = () => {
+        updateResources();
+    };
+
     return (
         <AppBar
             position="absolute"
@@ -194,6 +211,13 @@ const _AppBar: React.FC<AppBarProps> = ({classes, appName, openDialog}: AppBarPr
                     {appName}
                 </Typography>
                 <UserControl/>
+                {allowRefresh &&
+                    <Tooltip arrow title={i18n.get('Refresh')}>
+                        <IconButton onClick={handleRefresh} size="small" className={classes.iconButton}>
+                            <RefreshIcon/>
+                        </IconButton>
+                    </Tooltip>
+                }
                 <Tooltip arrow title={i18n.get('Help')}>
                     <IconButton onClick={handleOpenHelpMenu} size="small" className={classes.iconButton}>
                         <HelpOutlineIcon/>

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -16,8 +16,9 @@
     "logoWidth": 32,
     "baseMapUrl": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
     "defaultAgg": "mean",
-    "allowDownloads": true,
     "polygonFillOpacity": 0.2,
-    "mapProjection": "EPSG:4326"
+    "mapProjection": "EPSG:4326",
+    "allowDownloads": true,
+    "allowRefresh": true
   }
 }

--- a/src/resources/config.schema.json
+++ b/src/resources/config.schema.json
@@ -84,7 +84,6 @@
           "example": "mean",
           "enum": ["mean", "median", "min", "max"]
         },
-        "allowDownloads": {"type": "boolean", "example": true},
         "polygonFillOpacity": {
           "type": "number",
           "minimum": 0.0,
@@ -94,6 +93,14 @@
         "mapProjection": {
           "enum": ["EPSG:4326", "EPSG:3857"],
           "default": "EPSG:4326"
+        },
+        "allowDownloads": {
+          "type": "boolean",
+          "default": true
+        },
+        "allowRefresh": {
+          "type": "boolean",
+          "default": true
         }
       },
       "additionalProperties": false

--- a/src/resources/lang.json
+++ b/src/resources/lang.json
@@ -762,6 +762,13 @@
       "it": "Seleziona l'ora nel set di dati",
       "ro": "Selectați ora în setul de date",
       "se": "Välj tid i dataset"
+    },
+    {
+      "en": "Refresh",
+      "de": "Aktualisieren",
+      "it": "Aggiornare",
+      "ro": "A updata",
+      "se": "Att uppdatera"
     }
   ]
 }

--- a/src/util/branding.ts
+++ b/src/util/branding.ts
@@ -72,6 +72,9 @@ const COLORS: { [name: string]: Partial<Color> } = {
     yellow,
 };
 
+// Align any changes made here with
+// - resources/config.json
+// - resources/config.schema.json
 export interface Branding {
     appBarTitle: string;
     windowTitle: string;
@@ -87,8 +90,9 @@ export interface Branding {
     baseMapUrl?: string;
     defaultAgg?: 'median' | 'mean';
     polygonFillOpacity?: number;
-    allowDownloads?: boolean;
     mapProjection?: string;
+    allowDownloads?: boolean;
+    allowRefresh?: boolean;
 }
 
 


### PR DESCRIPTION
A new refresh icon in the main bar now allows updating server-side resources and refresh the page. For this to work, the configuration setting  `branding.allowRefresh` must be `true`.

**IMPORTANT:** Requires https://github.com/dcs4cop/xcube/pull/696