### PR TITLE
URL-encode Tile URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Changes in version 0.13.1 (in development)
 
+### Fixes
+
+* Tiles of datasets with forward slashes in their identifiers 
+  (originated from nested directories) now display again correctly. 
+  Tile URLs have not been URL-encoded in such cases. (#269)
+
 
 ## Changes in version 0.13.0
 

--- a/src/selectors/controlSelectors.tsx
+++ b/src/selectors/controlSelectors.tsx
@@ -705,7 +705,12 @@ export const selectedDatasetRgbLayerSelector = createSelector(
 function getTileUrl(serverUrl: string,
                     datasetId: string,
                     varName: string): string {
-    return `${serverUrl}/tiles/${datasetId}/${varName}/` + '{z}/{y}/{x}';
+    return (serverUrl
+        + '/tiles/'
+        + encodeURIComponent(datasetId)
+        + '/'
+        + encodeURIComponent(varName)
+        + '/{z}/{y}/{x}');
 }
 
 export function getDefaultFillOpacity() {


### PR DESCRIPTION
Tiles of datasets with forward slashes in their identifiers (originated from nested directories) now display again correctly. Tile URLs have not been URL-encoded in such cases. 

Closes #269.