### PR TITLE
Window crashing on resizing issue resolved

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
 * Fixed a crash when plotting more than 10 points on map. (#299)
 
+* Fixed a crash when resizing window. (#301)
+
 ## Changes in version 1.1.0
 
 * A certain column of an imported CSV table or a property of an imported GeoJSON

--- a/src/connected/Workspace.tsx
+++ b/src/connected/Workspace.tsx
@@ -117,7 +117,32 @@ const Workspace: React.FC<WorkspaceProps> = ({
                                              }) => {
     const [map, setMap] = React.useState<OlMap | null>(null);
     const [layout, setLayout] = React.useState<Layout>(getLayout());
+    const useBeforeRender = (callback: any) => {
+        const [isRun, setIsRun] = React.useState(false);
 
+        if (!isRun) {
+            callback();
+            setIsRun(true);
+        }
+    };
+
+    useBeforeRender(() => {
+        window.addEventListener("error", (e) => {
+            if (e) {
+                const resizeObserverErrDiv = document.getElementById(
+                    "webpack-dev-server-client-overlay-div",
+                );
+                const resizeObserverErr = document.getElementById(
+                    "webpack-dev-server-client-overlay",
+                );
+                if (resizeObserverErr)
+                    resizeObserverErr.className = "hide-resize-observer";
+                if (resizeObserverErrDiv)
+                    resizeObserverErrDiv.className = "hide-resize-observer";
+            }
+        });
+    });
+                                              
     React.useEffect(() => {
         updateLayout();
         window.onresize = updateLayout;

--- a/src/connected/Workspace.tsx
+++ b/src/connected/Workspace.tsx
@@ -128,7 +128,7 @@ const Workspace: React.FC<WorkspaceProps> = ({
 
     useBeforeRender(() => {
         window.addEventListener("error", (e) => {
-            if (e) {
+            if (e.message == "ResizeObserver loop completed with undelivered notifications.") {
                 const resizeObserverErrDiv = document.getElementById(
                     "webpack-dev-server-client-overlay-div",
                 );

--- a/src/index.css
+++ b/src/index.css
@@ -29,3 +29,7 @@ body {
     height: 100vh;
     font-family: "Roboto", "Segoe UI", "sans-serif";
 }
+
+.hide-resize-observer {
+    display: none !important;
+}


### PR DESCRIPTION
This error was encountered when we are trying to resize the browser window or even open the developer options.
To resolve this error, I have written a workaround to catch this error and then hiding the element. Since this error doesn't break our current/running workflow this solution is quite reasonable. 
We can make changes in future if we find a better solution than this. 
Please refer below links I found and used for workaround for this issue :

https://stackoverflow.com/questions/75774800/how-to-stop-resizeobserver-loop-limit-exceeded-error-from-appearing-in-react-a
https://gitlab.com/gitlab-org/gitlab-ui/-/issues/2233